### PR TITLE
Add struct for terminal size

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod color;
 mod finder;
 mod insh;
 mod searcher;
+mod terminal_size;
 mod vim;
 mod walker;
 

--- a/src/terminal_size.rs
+++ b/src/terminal_size.rs
@@ -1,0 +1,13 @@
+pub struct TerminalSize {
+    pub width: u16,
+    pub height: u16,
+}
+
+impl From<(u16, u16)> for TerminalSize {
+    fn from(tuple: (u16, u16)) -> TerminalSize {
+        TerminalSize {
+            width: tuple.0,
+            height: tuple.1,
+        }
+    }
+}


### PR DESCRIPTION
Add a struct for the terminal size so that we can refer to the
width and height instead of tuple indices.