### PR TITLE
Use git rev-parse for repo root

### DIFF
--- a/scripts/all.sh
+++ b/scripts/all.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HERE="${REPO_ROOT}/scripts"
 
 cd "${HERE}"
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,8 +2,7 @@
 
 set -euo pipefail
 
-HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
-REPO_ROOT="$(realpath "${HERE}/..")"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 cd "${REPO_ROOT}"
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -2,8 +2,7 @@
 
 set -euo pipefail
 
-HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
-REPO_ROOT="$(realpath "${HERE}/..")"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 cd "${REPO_ROOT}"
 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -2,8 +2,7 @@
 
 set -euo pipefail
 
-HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
-REPO_ROOT="$(realpath "${HERE}/..")"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 cd "${REPO_ROOT}"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,8 +2,7 @@
 
 set -euo pipefail
 
-HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
-REPO_ROOT="$(realpath "${HERE}/..")"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 cd "${REPO_ROOT}"
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,8 +2,7 @@
 
 set -euo pipefail
 
-HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
-REPO_ROOT="$(realpath "${HERE}/..")"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 cd "${REPO_ROOT}"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,8 +2,7 @@
 
 set -euo pipefail
 
-HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
-REPO_ROOT="$(realpath "${HERE}/..")"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 cd "${REPO_ROOT}"
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -2,8 +2,7 @@
 
 set -euo pipefail
 
-HERE="$(dirname "$(readlink -f "$BASH_SOURCE")")"
-REPO_ROOT="$(realpath "${HERE}/..")"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 cd "${REPO_ROOT}"
 


### PR DESCRIPTION
In bash scripts, use `git rev-parse --show-toplevel` to determing the
root directory of the repository instead of determining it relative to
the directory of the bash script. The reason for doing this is that on
Mac Os X the `readlink` command does not have the `-f` flag which was
being used.