### PR TITLE
Change the input bar colors

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -1,8 +1,15 @@
 use crossterm::style::Color as CrosstermColor;
 
+const DARK_GREY: CrosstermColor = CrosstermColor::Rgb {
+    r: 96,
+    g: 96,
+    b: 96,
+};
+
 pub enum Color {
     Highlight,
     InvertedText,
+    InvertedBackground,
     BadRegex,
     NotCompiledRegex,
 }
@@ -12,8 +19,9 @@ impl From<Color> for CrosstermColor {
         match color {
             Color::Highlight => CrosstermColor::Yellow,
             Color::InvertedText => CrosstermColor::Black,
+            Color::InvertedBackground => CrosstermColor::White,
             Color::BadRegex => CrosstermColor::Red,
-            Color::NotCompiledRegex => CrosstermColor::Grey,
+            Color::NotCompiledRegex => DARK_GREY,
         }
     }
 }


### PR DESCRIPTION
Change the input bar colors in find mode and search mode. Specifically,
make the background white and adjust the not compiled regex text color
to be a bit darker.