### PR TITLE
Remove mutability for derived state

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -85,7 +85,7 @@ impl Default for FindState {
 }
 
 impl FindState {
-    pub fn selected_path(&mut self) -> PathBuf {
+    pub fn selected_path(&self) -> PathBuf {
         let index = self.offset + self.selected;
         self.found[index].path()
     }


### PR DESCRIPTION
Do not let the selected path derived state of find mutate the find
state.