### PR TITLE
Use tilde for home directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,6 @@
 # 0.2.1
 - Add back refreshing the contents of the file browser with `r`.
+
+# 0.2.2
+- Use `~` to represent the home directory.
+- Change the directory to end with a trailing path separator.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,10 +81,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "getrandom"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "hashbrown"
@@ -117,6 +148,7 @@ version = "0.2.1"
 dependencies = [
  "clap",
  "crossterm",
+ "dirs",
  "itertools",
  "regex",
  "test-case",
@@ -269,11 +301,22 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7776223e2696f1aa4c6b0170e83212f47296a00424305117d013dfe86fb0fe55"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -381,6 +424,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +460,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 crossterm = "0.23.0"
 regex = "1.5.4"
 clap = "3.1.0"
+dirs = "4.0.0"
 unicode-segmentation = "1.9.0"
 itertools = "0.10.3"
 

--- a/src/components/common/directory.rs
+++ b/src/components/common/directory.rs
@@ -82,15 +82,34 @@ mod state {
     use crate::stateful::Stateful;
 
     use std::env;
-    use std::path::PathBuf;
+    use std::path::{PathBuf, MAIN_SEPARATOR as PATH_SEPARATOR};
 
     pub struct State {
         directory: PathBuf,
+        home: Option<PathBuf>,
     }
 
     impl State {
         pub fn directory_string(&self) -> String {
-            self.directory.to_str().unwrap().to_string()
+            let mut string: String;
+            if let Some(home) = &self.home {
+                if let Ok(path) = self.directory.strip_prefix(home) {
+                    let mut string = String::from("~");
+                    string.push(PATH_SEPARATOR);
+
+                    let path_string = path.to_str().unwrap();
+                    if path_string.len() > 0 {
+                        string.push_str(path.to_str().unwrap());
+                        string.push(PATH_SEPARATOR);
+                    }
+
+                    return string;
+                }
+            }
+
+            let mut string = self.directory.to_str().unwrap().to_string();
+            string.push(PATH_SEPARATOR);
+            string
         }
 
         fn set_directory(&mut self, directory: PathBuf) {
@@ -105,7 +124,8 @@ mod state {
     impl Default for State {
         fn default() -> Self {
             let directory: PathBuf = env::current_dir().unwrap();
-            State { directory }
+            let home: Option<PathBuf> = dirs::home_dir();
+            State { directory, home }
         }
     }
 


### PR DESCRIPTION
Use a tilde for the home directory. And also make the directory end with
a trailing path separator.