### PR TITLE
Fix finder depth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "insh"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "clap",
  "crossterm",

--- a/src/path_finder.rs
+++ b/src/path_finder.rs
@@ -13,7 +13,7 @@ pub struct PathFinder {
 impl PathFinder {
     pub fn new(directory: &Path, pattern: &str) -> Result<Self, regex::Error> {
         let regex = Regex::new(pattern)?;
-        let walker = WalkerBuilder::new(directory).into_iter();
+        let walker = WalkerBuilder::new(directory).min_depth(1).into_iter();
 
         Ok(PathFinder { regex, walker })
     }


### PR DESCRIPTION
Fix the depth that the finder looks for files in so that it does not
include the name of current directory.