### PR TITLE
Fix g command in finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 # 0.2.3
 - Fix crashing of finder from there being too many files open.
 - Fix the displayed directory in the finder.
+- Fix the directory that the goto command (`g`) in the finder navigates to.

--- a/src/components/browse/browse.rs
+++ b/src/components/browse/browse.rs
@@ -1,6 +1,6 @@
 use super::{ContentsComponent, ContentsEffect, ContentsEvent, ContentsProps};
 use crate::component::Component;
-use crate::components::common::{Directory, DirectoryEffect, DirectoryEvent};
+use crate::components::common::{Directory, DirectoryEffect, DirectoryEvent, DirectoryProps};
 use crate::rendering::{Fabric, Size};
 use crate::stateful::Stateful;
 
@@ -25,7 +25,7 @@ pub struct Browse {
 
 impl Component<Props, Event, Effect> for Browse {
     fn new(props: Props) -> Self {
-        let state = State::new(props);
+        let state = State::from(props);
         Self { state }
     }
 
@@ -97,12 +97,14 @@ struct State {
     focus: Focus,
 }
 
-impl State {
-    fn new(props: Props) -> Self {
-        let directory = Directory::default();
+impl From<Props> for State {
+    fn from(props: Props) -> Self {
+        let directory_props = DirectoryProps::new(props.directory.clone());
+        let directory = Directory::new(directory_props);
 
         let contents_size = Size::new(props.size.rows - 1, props.size.columns);
-        let contents = ContentsComponent::new(ContentsProps::new(contents_size));
+        let contents_props = ContentsProps::new(props.directory, contents_size);
+        let contents = ContentsComponent::new(contents_props);
 
         let focus = Focus::default();
         State {

--- a/src/components/browse/contents.rs
+++ b/src/components/browse/contents.rs
@@ -12,12 +12,13 @@ use std::path::PathBuf;
 use crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEvent};
 
 pub struct Props {
+    directory: PathBuf,
     size: Size,
 }
 
 impl Props {
-    pub fn new(size: Size) -> Self {
-        Self { size }
+    pub fn new(directory: PathBuf, size: Size) -> Self {
+        Self { directory, size }
     }
 }
 
@@ -27,7 +28,7 @@ pub struct Contents {
 
 impl Component<Props, Event, Effect> for Contents {
     fn new(props: Props) -> Self {
-        let state = State::new(props.size);
+        let state = State::from(props);
         Self { state }
     }
 
@@ -130,8 +131,9 @@ struct State {
 }
 
 impl State {
-    pub fn new(size: Size) -> Self {
-        let directory: PathBuf = env::current_dir().unwrap();
+    pub fn from(props: Props) -> Self {
+        let size = props.size;
+        let directory: PathBuf = props.directory;
         let entries = State::get_entries(&directory);
         let selected = if !entries.is_empty() { Some(0) } else { None };
         let offset = 0;

--- a/src/components/finder/found.rs
+++ b/src/components/finder/found.rs
@@ -302,9 +302,15 @@ mod state {
         }
 
         fn goto(&mut self) -> Option<Effect> {
-            Some(Effect::Goto {
-                directory: self.directory.clone(),
-            })
+            match self.entry_path() {
+                Some(entry) => {
+                    let destination = entry.parent().unwrap().to_path_buf();
+                    Some(Effect::Goto {
+                        directory: destination,
+                    })
+                }
+                None => None,
+            }
         }
     }
 


### PR DESCRIPTION
Fix the directory that the `g` command in the file finder navigates to.