### PR TITLE
Add reset finder offset when run

### DIFF
--- a/src/components/finder/found.rs
+++ b/src/components/finder/found.rs
@@ -251,6 +251,7 @@ mod state {
             // TODO: handle regex errors!
             let path_finder = PathFinder::new(&self.directory, &phrase).unwrap();
             self.entries = path_finder.collect();
+            self.offset = 0;
 
             if self.entries.is_empty() {
                 self.selected = None;


### PR DESCRIPTION
Make sure to reset the finder contents offset when a find is run.