### PR TITLE
Fix displaying of root dir

### DIFF
--- a/src/components/common/directory.rs
+++ b/src/components/common/directory.rs
@@ -108,7 +108,9 @@ mod state {
             }
 
             let mut string = self.directory.to_str().unwrap().to_string();
-            string.push(PATH_SEPARATOR);
+            if self.directory.parent().is_some() {
+                string.push(PATH_SEPARATOR);
+            }
             string
         }
 


### PR DESCRIPTION
Fix the displaying of the root directory in directory component. (There
was an extra path separator being appended to the directory.)