### PR TITLE
Fix flickering

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -91,6 +91,7 @@ impl App {
         self.lazy_enable_alternate_terminal();
         self.enable_raw_terminal();
         self.lazy_hide_cursor();
+        self.lazy_clear_screen();
 
         self.change_panic_hook();
     }

--- a/src/components/browser/contents.rs
+++ b/src/components/browser/contents.rs
@@ -40,7 +40,8 @@ impl Component<Props, Event, Effect> for Contents {
 
     fn render(&self, size: Size) -> Fabric {
         let mut yarns: Vec<Yarn> = Vec::new();
-        for (entry, row) in self.state.visible_entries().iter().zip(0..size.rows) {
+        let visible_entries = self.state.visible_entries();
+        for (entry, row) in visible_entries.iter().zip(0..size.rows) {
             let mut string: String;
             {
                 let path = entry.path();
@@ -60,9 +61,17 @@ impl Component<Props, Event, Effect> for Contents {
             } else if hidden {
                 yarn.color(Color::LightGrayyedText.into());
             }
+            yarn.resize(size.columns);
             yarns.push(yarn);
         }
-        Fabric::from(yarns)
+
+        let mut fabric = Fabric::from(yarns);
+
+        if fabric.size().rows < size.rows {
+            fabric.pad_bottom(size.rows);
+        }
+
+        fabric
     }
 }
 

--- a/src/components/finder/contents.rs
+++ b/src/components/finder/contents.rs
@@ -100,11 +100,18 @@ mod contents {
                             yarn.color_before(Color::GrayyedText.into(), file_name_start);
                         }
 
-                        yarn.truncate(size.columns);
+                        yarn.resize(size.columns);
 
                         yarns.push(yarn);
                     }
-                    Fabric::from(yarns)
+
+                    let mut fabric = Fabric::from(yarns);
+
+                    if fabric.size().rows < size.rows {
+                        fabric.pad_bottom(size.rows);
+                    }
+
+                    fabric
                 }
                 Some(false) => {
                     let mut yarn = Yarn::from("No matching files.");

--- a/src/components/searcher/contents.rs
+++ b/src/components/searcher/contents.rs
@@ -160,7 +160,13 @@ mod contents {
                             yarns.push(yarn);
                         }
 
-                        Fabric::from(yarns)
+                        let mut fabric = Fabric::from(yarns);
+
+                        if fabric.size().rows < size.rows {
+                            fabric.pad_bottom(size.rows);
+                        }
+
+                        fabric
                     }
                 }
             }

--- a/src/rendering/fabric.rs
+++ b/src/rendering/fabric.rs
@@ -5,7 +5,7 @@ use std::cmp::Ordering;
 use crossterm::style::Color;
 use itertools::izip;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Fabric {
     size: Size,
     characters: Vec<Vec<char>>,
@@ -26,6 +26,12 @@ impl Fabric {
             colors,
             backgrounds,
         }
+    }
+
+    /// Return the size of the fabric.
+    #[allow(dead_code)]
+    pub fn size(&self) -> Size {
+        self.size
     }
 
     #[allow(dead_code)]
@@ -50,7 +56,7 @@ impl Fabric {
         &self.backgrounds
     }
 
-    /// Vertically pad the fabric to `new_rows`.
+    /// Vertically pad the fabric to `new_rows` by adding rows above and below.
     ///
     /// If the new number of rows is less than the current rows, then panic (for now).
     pub fn pad(&mut self, new_rows: usize) {
@@ -79,6 +85,26 @@ impl Fabric {
                     vec![vec![None; self.size.columns]; bottom_pad_rows],
                 ]
                 .concat();
+            }
+            Ordering::Less => {
+                panic!("Cannot pad a yarn to smaller than the current rows.")
+            }
+            Ordering::Equal => {}
+        }
+    }
+
+    /// Verically pad the fabric to the new number of rows by adding rows below.
+    ///
+    /// Panic if the new number of rows is less than the current number of rows.
+    pub fn pad_bottom(&mut self, new_rows: usize) {
+        match new_rows.cmp(&self.size.rows) {
+            Ordering::Greater => {
+                let difference: usize = new_rows - self.size.rows;
+                let columns: usize = self.size.columns;
+
+                self.characters.extend(vec![vec![' '; columns]; difference]);
+                self.colors.extend(vec![vec![]; difference]);
+                self.backgrounds.extend(vec![vec![]; difference]);
             }
             Ordering::Less => {
                 panic!("Cannot pad a yarn to smaller than the current rows.")

--- a/src/rendering/renderer.rs
+++ b/src/rendering/renderer.rs
@@ -18,8 +18,6 @@ impl Renderer {
     }
 
     pub fn render(&mut self, fabric: Fabric) {
-        self.lazy_clear_screen();
-
         let attributes = itertools::izip!(
             0..,
             fabric.characters(),
@@ -70,6 +68,7 @@ impl Renderer {
             .unwrap();
     }
 
+    #[allow(dead_code)]
     fn lazy_clear_screen(&mut self) {
         self.stdout
             .queue(ClearTerminal(TerminalClearType::All))


### PR DESCRIPTION
Fix the flickering of text. Flickering was being caused by clearing the
terminal on each render. Instead, just draw the fabric without clearing
the screen.

There were a number of places where the fabric (or yarns of the fabric)
were not being created with the correct size so fix those too. I had
been thinking that we could use fuzzing to check that yarns and fabrics
are always the right size, but alternatively, it might make sense to
change the render method to have a fabric as a parameter and change the
fabric parameter have checks against being incorrectly sized.