### PR TITLE
Fix trailing slash in directory bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,6 @@ means that symbolic links are no longer resolved.
 - Add refresh (`r`) command to the searcher and finder.
 - Add scroll to bottom (`J`) and scroll to top (`K`) commands to the browser, finder, and searcher.
 - Add scroll view down (`<Ctrl>-j`) and scroll view up (`<Ctrl>-k`) to searcher.
+
+# 0.3.8
+- Fix bugs related to running with `-d` and a trailing slash in the directory argument.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "insh"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "clap",
  "copypasta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insh"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 
 [dependencies]

--- a/src/components/finder/contents.rs
+++ b/src/components/finder/contents.rs
@@ -113,7 +113,9 @@ mod contents {
                         let path: &Path = entry.path();
                         let mut string: &str = &path.to_string_lossy();
                         string = string.strip_prefix(&directory).unwrap();
-                        string = string.strip_prefix(PATH_SEPARATOR).unwrap();
+                        if string.starts_with(PATH_SEPARATOR) {
+                            string = string.strip_prefix(PATH_SEPARATOR).unwrap();
+                        }
                         let mut yarn: Yarn = Yarn::from(string);
 
                         let file_name_start: usize = yarn.len() - entry.file_name().len();
@@ -415,7 +417,9 @@ mod state {
                 if !really {
                     let directory_string: String = self.directory().to_string_lossy().to_string();
                     path = path.strip_prefix(&directory_string).unwrap().to_string();
-                    path = path.strip_prefix(PATH_SEPARATOR).unwrap().to_string();
+                    if path.starts_with(PATH_SEPARATOR) {
+                        path = path.strip_prefix(PATH_SEPARATOR).unwrap().to_string();
+                    }
                 }
                 let mut clipboard = Clipboard::new();
                 clipboard.copy(path);

--- a/src/components/searcher/contents.rs
+++ b/src/components/searcher/contents.rs
@@ -144,7 +144,9 @@ mod contents {
                                 let directory_string: String =
                                     self.state.directory().to_string_lossy().to_string();
                                 path = path.strip_prefix(&directory_string).unwrap().to_string();
-                                path = path.strip_prefix(PATH_SEPARATOR).unwrap().to_string();
+                                if path.starts_with(PATH_SEPARATOR) {
+                                    path = path.strip_prefix(PATH_SEPARATOR).unwrap().to_string();
+                                }
 
                                 let mut yarn = Yarn::from(path);
                                 yarn.resize(columns);
@@ -688,7 +690,9 @@ mod state {
                             let directory_string: String =
                                 self.directory().to_string_lossy().to_string();
                             path = path.strip_prefix(&directory_string).unwrap().to_string();
-                            path = path.strip_prefix(PATH_SEPARATOR).unwrap().to_string();
+                            if path.starts_with(PATH_SEPARATOR) {
+                                path = path.strip_prefix(PATH_SEPARATOR).unwrap().to_string();
+                            }
                         }
                         path
                     }


### PR DESCRIPTION
Fix the following bugs related to running `insh` with a trailing slash
in the directory (using the `-d` flag):
- The Searcher would crash if there were hits
- The Finder would crash if there were hits
- Yanking a relative path in the Searcher would crash
- Yanking a relative path in the Finder would crash