### PR TITLE
Add edit subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.9
+- Bump the `clap` dependency from version `3.1.14` to version `3.2.17`.
+
 # 0.3.8
 - Fix bugs related to running with `-d` and a trailing slash in the directory argument.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.3.9
 - Bump the `clap` dependency from version `3.1.14` to version `3.2.17`.
+- Add an `edit` subcommand.
 
 # 0.3.8
 - Fix bugs related to running with `-d` and a trailing slash in the directory argument.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,16 +54,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.14"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535434c063ced786eb04aaf529308092c5ab60889e8fe24275d15de07b01fa97"
+checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "insh"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "clap",
  "copypasta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "insh"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 
 [dependencies]
 crossterm = "0.23.0"
 regex = "1.5.4"
-clap = { version = "3.1.14", features = ["derive"] }
+clap = { version = "3.2.17", features = ["derive"] }
 dirs = "4.0.0"
 unicode-segmentation = "1.9.0"
 itertools = "0.10.3"

--- a/src/app.rs
+++ b/src/app.rs
@@ -26,8 +26,26 @@ impl App {
         App { stdout, renderer }
     }
 
-    pub fn run<Props>(&mut self, root: &mut impl Component<Props, CrosstermEvent, SystemEffect>) {
+    pub fn run<Props>(
+        &mut self,
+        root: &mut impl Component<Props, CrosstermEvent, SystemEffect>,
+        starting_effects: Option<Vec<SystemEffect>>,
+    ) {
         self.set_up();
+
+        if let Some(effects) = starting_effects {
+            for effect in effects {
+                match effect {
+                    SystemEffect::Exit => {
+                        self.teardown();
+                        return;
+                    }
+                    SystemEffect::RunProgram { program } => {
+                        self.run_program(program);
+                    }
+                }
+            }
+        }
 
         loop {
             let size: Size = Size::from(terminal::size().unwrap());

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,8 +1,11 @@
+use crate::programs::{Vim, VimArgs, VimArgsBuilder};
+use crate::system_effect::SystemEffect;
+
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 #[clap(author, version, about)]
 pub struct Args {
     /// Starting directory to run in
@@ -21,9 +24,41 @@ impl Args {
     pub fn command(&self) -> &Option<Command> {
         &self.command
     }
+
+    pub fn starting_effects(&self) -> Option<Vec<SystemEffect>> {
+        match &self.command {
+            Some(Command::Edit {
+                browse,
+                file_line_column,
+            }) => {
+                let mut vim_args_builder = VimArgsBuilder::new();
+                if let Some(file_line_column) = file_line_column {
+                    if let Some(file) = file_line_column.file() {
+                        vim_args_builder = vim_args_builder.path(file);
+                    }
+                    if let Some(line) = file_line_column.line() {
+                        vim_args_builder = vim_args_builder.line(line);
+                    }
+                    if let Some(column) = file_line_column.column() {
+                        vim_args_builder = vim_args_builder.column(column);
+                    }
+                }
+                let vim_args: VimArgs = vim_args_builder.build();
+                let program = Box::new(Vim::new(vim_args));
+                let run_vim = SystemEffect::RunProgram { program };
+                let mut effects: Vec<SystemEffect> = vec![run_vim];
+
+                if !browse {
+                    effects.push(SystemEffect::Exit)
+                }
+                Some(effects)
+            }
+            _ => None,
+        }
+    }
 }
 
-#[derive(Subcommand, Clone)]
+#[derive(Subcommand, Clone, Debug)]
 pub enum Command {
     /// Browse a directory
     #[clap(alias = "b", display_order = 1)]
@@ -36,4 +71,277 @@ pub enum Command {
     /// Search file contents
     #[clap(alias = "s", display_order = 3)]
     Search { phrase: Option<String> },
+
+    /// Edit a file
+    ///
+    /// Edit a file using the editor if a file is provided or just open the editor if no file is
+    /// provided.
+    #[clap(alias = "e", display_order = 4, value_parser)]
+    Edit {
+        /// Open the browser afterwards
+        ///
+        /// The directory is the directory the file is in or if the global `directory` argument is
+        /// provided, then it is used.
+        #[clap(short, long)]
+        browse: bool,
+
+        /// The file to edit
+        ///
+        /// Of the form "<file>", "<file>:<line>" or "<file>:<line>,<column>".
+        #[clap(name = "FILE")]
+        file_line_column: Option<FileLineColumn>,
+    },
+}
+
+mod file_line_column {
+    use super::file_line_column_parse_error::FileLineColumnParseError;
+
+    use std::fmt::{Display, Error as FmtError, Formatter};
+    use std::path::PathBuf;
+    use std::str::FromStr;
+
+    /// A file, line, and column number. The line and column numbers are 1-based.
+    #[derive(Clone, Debug, Default, PartialEq, Eq)]
+    pub struct FileLineColumn {
+        file: Option<PathBuf>,
+        line: Option<usize>,
+        column: Option<usize>,
+    }
+
+    impl FileLineColumn {
+        pub fn new(file: Option<PathBuf>, line: Option<usize>, column: Option<usize>) -> Self {
+            Self { file, line, column }
+        }
+
+        pub fn file(&self) -> &Option<PathBuf> {
+            &self.file
+        }
+
+        pub fn line(&self) -> Option<usize> {
+            self.line
+        }
+
+        pub fn column(&self) -> Option<usize> {
+            self.column
+        }
+    }
+
+    impl Display for FileLineColumn {
+        fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
+            if let Some(file) = &self.file {
+                write!(f, "{}", file.display())?;
+            } else {
+                return Ok(());
+            }
+
+            if let Some(line) = self.line {
+                write!(f, ":{}", line)?;
+            }
+
+            if let Some(column) = self.column {
+                write!(f, ",{}", column)?;
+            }
+            Ok(())
+        }
+    }
+
+    impl FromStr for FileLineColumn {
+        type Err = FileLineColumnParseError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            if s.is_empty() {
+                return Ok(FileLineColumn::default());
+            }
+            let file_string: &str;
+            let line_and_maybe_column_string: Option<&str>;
+            match s.rsplit_once(':') {
+                Some((file_, line_and_maybe_column_string_)) => {
+                    file_string = file_;
+                    line_and_maybe_column_string = Some(line_and_maybe_column_string_);
+                }
+                None => {
+                    file_string = s;
+                    line_and_maybe_column_string = None;
+                }
+            }
+
+            let line_string: Option<&str>;
+            let column_string: Option<&str>;
+            match line_and_maybe_column_string {
+                Some(line_and_maybe_column_) => match line_and_maybe_column_.rsplit_once(',') {
+                    Some((line_, column_)) => {
+                        line_string = Some(line_);
+                        column_string = Some(column_);
+                    }
+                    None => {
+                        line_string = Some(line_and_maybe_column_);
+                        column_string = None;
+                    }
+                },
+                None => {
+                    line_string = None;
+                    column_string = None;
+                }
+            }
+
+            let mut bad_file: Option<String> = None;
+            let mut bad_line: Option<String> = None;
+            let mut bad_column: Option<String> = None;
+
+            let mut file: Option<PathBuf> = None;
+            let mut line: Option<usize> = None;
+            let mut column: Option<usize> = None;
+
+            match PathBuf::try_from(file_string) {
+                Ok(file_) => {
+                    file = Some(file_);
+                }
+                Err(_) => {
+                    bad_file = Some(file_string.into());
+                }
+            };
+
+            if let Some(line_string_) = line_string {
+                match usize::from_str(line_string_) {
+                    Ok(line_) => {
+                        line = Some(line_);
+                    }
+                    Err(_) => {
+                        bad_line = Some(line_string_.into());
+                    }
+                };
+            }
+
+            if let Some(column_string_) = column_string {
+                match usize::from_str(column_string_) {
+                    Ok(column_) => {
+                        column = Some(column_);
+                    }
+                    Err(_) => {
+                        bad_column = Some(column_string_.into());
+                    }
+                };
+            }
+
+            if bad_file.is_some() || bad_line.is_some() || bad_column.is_some() {
+                Err(FileLineColumnParseError::new(
+                    bad_file, bad_line, bad_column,
+                ))
+            } else {
+                Ok(FileLineColumn::new(file, line, column))
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use test_case::test_case;
+
+        #[test_case("", Ok(FileLineColumn::new(None, None, None)); "when the string is empty")]
+        #[test_case("foo.py", Ok(FileLineColumn::new(Some("foo.py".into()), None, None)); "file")]
+        #[test_case("foo.py:xx", Err(FileLineColumnParseError::from_bad_line("xx".into())); "file and bad line")]
+        #[test_case("foo.py:42", Ok(FileLineColumn::new(Some("foo.py".into()), Some(42), None)); "file and line")]
+        #[test_case("foo.py:42,xx", Err(FileLineColumnParseError::from_bad_column("xx".into())); "file, line, and bad column")]
+        #[test_case("foo.py:42,7", Ok(FileLineColumn::new(Some("foo.py".into()), Some(42), Some(7))); "file, line, and column")]
+        #[test_case("foo.py:xx,yy", Err(FileLineColumnParseError::new(None, Some("xx".into()), Some("yy".into()))); "file, bad line, and column")]
+        fn test_from_str(
+            string: &str,
+            expected_result: Result<FileLineColumn, FileLineColumnParseError>,
+        ) {
+            let result: Result<FileLineColumn, FileLineColumnParseError> =
+                FileLineColumn::from_str(string);
+
+            assert_eq!(result, expected_result)
+        }
+    }
+}
+pub use file_line_column::FileLineColumn;
+
+mod file_line_column_parse_error {
+    use crate::string::{capitalize_first_letter, conjoin};
+
+    use std::error::Error;
+    use std::fmt::{Display, Error as FmtError, Formatter};
+
+    #[derive(Debug, Default, PartialEq, Eq)]
+    pub struct FileLineColumnParseError {
+        bad_file: Option<String>,
+        bad_line: Option<String>,
+        bad_column: Option<String>,
+    }
+
+    impl FileLineColumnParseError {
+        /// Return a new parse error.
+        pub fn new(
+            bad_file: Option<String>,
+            bad_line: Option<String>,
+            bad_column: Option<String>,
+        ) -> Self {
+            Self {
+                bad_file,
+                bad_line,
+                bad_column,
+            }
+        }
+
+        /// Return a parse error from a string that cannot be parsed as a file.
+        #[allow(dead_code)]
+        pub fn from_bad_file(bad_file: String) -> Self {
+            Self {
+                bad_file: Some(bad_file),
+                ..Default::default()
+            }
+        }
+
+        /// Return a parse error from a string that cannot be parsed as a line number.
+        #[allow(dead_code)]
+        pub fn from_bad_line(bad_line: String) -> Self {
+            Self {
+                bad_line: Some(bad_line),
+                ..Default::default()
+            }
+        }
+
+        /// Return a parse error from a string that cannot be parsed as a column number.
+        #[allow(dead_code)]
+        pub fn from_bad_column(bad_column: String) -> Self {
+            Self {
+                bad_column: Some(bad_column),
+                ..Default::default()
+            }
+        }
+    }
+
+    impl Display for FileLineColumnParseError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
+            if self.bad_file.is_none() && self.bad_line.is_none() && self.bad_column.is_none() {
+                write!(
+                    f,
+                    "Something went wrong parsing the file, optional line, and or the optional column."
+                )?;
+                return Ok(());
+            }
+
+            let mut problems: Vec<String> = vec![];
+            if let Some(bad_file) = &self.bad_file {
+                problems.push(format!("could not parse \"{}\" as a file path", bad_file));
+            }
+            if let Some(bad_line) = &self.bad_line {
+                problems.push(format!("could not parse \"{}\" as a line number", bad_line));
+            }
+            if let Some(bad_column) = &self.bad_column {
+                problems.push(format!(
+                    "could not parse \"{}\" as a column number",
+                    bad_column
+                ));
+            }
+
+            problems[0] = capitalize_first_letter(&problems[0]);
+            let message: String = conjoin(problems, "and");
+            write!(f, "{}.", message)
+        }
+    }
+
+    impl Error for FileLineColumnParseError {}
 }

--- a/src/components/searcher/contents.rs
+++ b/src/components/searcher/contents.rs
@@ -636,7 +636,7 @@ mod state {
             if let Some(line_hit_number) = self.line_hit_number() {
                 let line_hit: &LineHit = &file_hit.line_hits()[line_hit_number];
                 let line_number = line_hit.line_number();
-                vim_args_builder = vim_args_builder.line_number(line_number);
+                vim_args_builder = vim_args_builder.line(line_number);
             }
             let vim_args: VimArgs = vim_args_builder.build();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,22 +14,26 @@ mod program;
 mod programs;
 mod rendering;
 mod stateful;
+mod string;
 mod system_effect;
 
-use app::App;
-use args::Args;
-use component::Component;
-use components::{Insh, InshProps};
-use stateful::Stateful;
+use crate::app::App;
+use crate::args::Args;
+use crate::component::Component;
+use crate::components::{Insh, InshProps};
+use crate::stateful::Stateful;
+use crate::system_effect::SystemEffect;
 
 use clap::Parser;
 
 fn main() {
     let args: Args = Args::parse();
+    let starting_effects: Option<Vec<SystemEffect>> = args.starting_effects();
+
     let insh_props: InshProps = InshProps::from(args);
 
     let mut app: App = App::new();
     let mut root = Insh::new(insh_props);
 
-    app.run(&mut root);
+    app.run(&mut root, starting_effects);
 }

--- a/src/programs/vim.rs
+++ b/src/programs/vim.rs
@@ -28,8 +28,15 @@ impl Program for Vim {
             command.arg(path.clone());
         }
 
-        if let Some(line_number) = self.args.line_number() {
-            command.arg(format!("+{}", line_number));
+        if let Some(line) = self.args.line() {
+            command.arg(format!("+{}", line));
+        }
+
+        if let Some(column) = self.args.column() {
+            if column > 1 {
+                command.arg("-c");
+                command.arg(format!("norm {}l", column - 1));
+            }
         }
 
         command.stdin(Stdio::inherit()).stdout(Stdio::inherit());
@@ -40,7 +47,8 @@ impl Program for Vim {
 
 pub struct Args {
     path: Option<PathBuf>,
-    line_number: Option<usize>,
+    line: Option<usize>,
+    column: Option<usize>,
 }
 
 impl Args {
@@ -48,15 +56,20 @@ impl Args {
         &self.path
     }
 
-    pub fn line_number(&self) -> Option<usize> {
-        self.line_number
+    pub fn line(&self) -> Option<usize> {
+        self.line
+    }
+
+    pub fn column(&self) -> Option<usize> {
+        self.column
     }
 }
 
 #[derive(Default)]
 pub struct ArgsBuilder {
     path: Option<PathBuf>,
-    line_number: Option<usize>,
+    line: Option<usize>,
+    column: Option<usize>,
 }
 
 impl ArgsBuilder {
@@ -71,15 +84,21 @@ impl ArgsBuilder {
         self
     }
 
-    pub fn line_number(mut self, line_number: usize) -> Self {
-        self.line_number = Some(line_number);
+    pub fn line(mut self, line: usize) -> Self {
+        self.line = Some(line);
+        self
+    }
+
+    pub fn column(mut self, column: usize) -> Self {
+        self.column = Some(column);
         self
     }
 
     pub fn build(&self) -> Args {
         Args {
             path: self.path.clone(),
-            line_number: self.line_number,
+            line: self.line,
+            column: self.column,
         }
     }
 }

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -1,0 +1,53 @@
+/// String helper methods.
+
+/// Return the `strings` joined together using commas, (an Oxoford comma if necessary), and the
+/// `conjuction`.
+pub fn conjoin(strings: Vec<String>, conjunction: &str) -> String {
+    match strings.len() {
+        0 => String::new(),
+        1 => strings[0].to_string(),
+        2 => format!("{} {} {}", strings[0], conjunction, strings[1]),
+        _ => {
+            strings[0..strings.len() - 1].join(", ")
+                + ", "
+                + conjunction
+                + " "
+                + &strings[strings.len() - 1]
+        }
+    }
+}
+
+/// Return the string with the first letter capitalized (if there is a first letter).
+pub fn capitalize_first_letter(string: &str) -> String {
+    if string.is_empty() {
+        return String::new();
+    }
+    string[0..1].to_uppercase() + &string[1..]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case(vec![], "and", ""; "joining no strings")]
+    #[test_case(vec![String::from("foo")], "and", "foo"; "joining a single string")]
+    #[test_case(vec![String::from("foo"), String::from("bar")],"and",  "foo and bar"; "oining two string")]
+    #[test_case(vec![String::from("foo"), String::from("bar"), String::from("baz")], "and", "foo, bar, and baz"; "joining three string")]
+    fn test_conjoin(strings: Vec<String>, conjunction: &str, expected_result: &str) {
+        let result: String = conjoin(strings, conjunction);
+
+        assert_eq!(result, expected_result);
+    }
+
+    #[test_case("", ""; "capitalizing the first letter of an empty string")]
+    #[test_case("a", "A"; "capitalizing the first letter of a string with one character")]
+    #[test_case("A", "A"; "capitalizing the first letter of a string with one character that is already capitalized")]
+    #[test_case("foo", "Foo"; "capitalizing the first letter of a string that has one word")]
+    #[test_case("Foo", "Foo"; "capitalizing the first letter of a string that has one word with an already capitalized first letter")]
+    fn test_capitalize_first_letter(string: &str, expected_result: &str) {
+        let result: String = capitalize_first_letter(string);
+
+        assert_eq!(result, expected_result);
+    }
+}


### PR DESCRIPTION
Add an edit subcommand to be able to directly run the editor. The main
reason for adding this is to be able to copy file, line and columns from
error messages and be able to go there directly.