### PR TITLE
Show message for empty directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.10
+- Add a message for an empty directory in the browser.
+- Fix crash when the width of the terminal is less than the length of the messages for no hits in the
+searcher and finder.
+
 # 0.3.9
 - Bump the `clap` dependency from version `3.1.14` to version `3.2.17`.
 - Add an `edit` subcommand.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "insh"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "clap",
  "copypasta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insh"
-version = "0.3.9"
+version = "0.3.10"
 edition = "2021"
 
 [dependencies]

--- a/src/components/browser/contents.rs
+++ b/src/components/browser/contents.rs
@@ -44,13 +44,12 @@ impl Component<Props, Event, Effect> for Contents {
     }
 
     fn render(&self, size: Size) -> Fabric {
-        let mut yarns: Vec<Yarn> = Vec::new();
-
         let visible_entries = self.state.visible_entries();
         if visible_entries.is_empty() {
-            return Fabric::new(size);
+            return Fabric::center("The directory is empty.", size);
         }
 
+        let mut yarns: Vec<Yarn> = Vec::new();
         for (entry, row) in visible_entries.iter().zip(0..size.rows) {
             let mut string: String;
             {

--- a/src/components/finder/contents.rs
+++ b/src/components/finder/contents.rs
@@ -141,13 +141,7 @@ mod contents {
 
                     fabric
                 }
-                Some(false) => {
-                    let mut yarn = Yarn::from("No matching files.");
-                    yarn.pad(size.columns);
-                    let mut fabric = Fabric::from(vec![yarn]);
-                    fabric.pad(size.rows);
-                    fabric
-                }
+                Some(false) => Fabric::center("No matching files.", size),
                 None => Fabric::new(size),
             }
         }

--- a/src/components/searcher/contents.rs
+++ b/src/components/searcher/contents.rs
@@ -117,11 +117,7 @@ mod contents {
                 true => {
                     let file_hits: &Vec<FileHit> = self.state.hits();
                     if self.state.hits().is_empty() {
-                        let mut yarn = Yarn::from("No matches.");
-                        yarn.pad(size.columns);
-                        let mut fabric = Fabric::from(vec![yarn]);
-                        fabric.pad(size.rows);
-                        fabric
+                        Fabric::center("No matches.", size)
                     } else {
                         let rows = size.rows;
                         let columns = size.columns;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![deny(warnings)]
 #![allow(clippy::module_inception)]
+#![allow(clippy::needless_return)]
 
 mod app;
 mod args;


### PR DESCRIPTION
Show a message for an empty directory in the browser. Also, fix the
crash that would occur if the length of centered messages was longer
than the terminal width.