### PR TITLE
Add searcher history and suggestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.11
+- Add searcher history.
+- Add searcher auto complete and `<Tab>` completion.
+- Add a configuration file.
+
 # 0.3.10
 - Add a message for an empty directory in the browser.
 - Fix crash when the width of the terminal is less than the length of the messages for no hits in the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -215,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -225,14 +235,18 @@ dependencies = [
 
 [[package]]
 name = "insh"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "clap",
  "copypasta",
  "crossterm",
  "dirs",
+ "fslock",
  "itertools",
+ "lazy_static",
  "regex",
+ "serde",
+ "serde_yaml",
  "test-case",
  "unicode-segmentation",
  "walkdir",
@@ -246,6 +260,12 @@ checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "lazy-bytes-cast"
@@ -493,11 +513,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -556,6 +576,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "ryu"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +601,39 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "serde"
+version = "1.0.144"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.144"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a09f551ccc8210268ef848f0bab37b306e87b85b2e017b899e7fb815f5aed62"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
 
 [[package]]
 name = "signal-hook"
@@ -648,13 +707,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -706,16 +765,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
-name = "unicode-xid"
+name = "unsafe-libyaml"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insh"
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 
 [dependencies]
@@ -11,7 +11,19 @@ dirs = "4.0.0"
 unicode-segmentation = "1.9.0"
 itertools = "0.10.3"
 walkdir = "2.3.2"
-copypasta = "0.8.1"  # Used to manage the clipboard.
+
+# Used to manage the clipboard.
+copypasta = "0.8.1"
+
+# Used to control access to persistent data stored in the file system.
+fslock = "0.2.1"
+
+# Used for serialization and deserialization of data structures.
+serde = { version = "1.0.144", features = ["derive"] }
+serde_yaml = "0.9.10"
+
+# Used for declaring lazily evaluated static values.
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 test-case = "2.0.0"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ the file name.
 | Any character | Append the character to the current input. |
 | `<Enter>`     | Search for files matching the input.       |
 | `<Backspace>` | Remove the last character from the input.  |
+| `<Tab>`       | Fill in the input with the suggestion.     |
 
 #### Found Files Commands:
 | Command          | Description                                                                |

--- a/src/auto_completer.rs
+++ b/src/auto_completer.rs
@@ -1,0 +1,4 @@
+/// Provides _completions_ of type `C` for _partial_ input of type `P`.
+pub trait AutoCompleter<P, C> {
+    fn complete(&mut self, partial: P) -> Option<C>;
+}

--- a/src/auto_completers/mod.rs
+++ b/src/auto_completers/mod.rs
@@ -1,0 +1,3 @@
+mod search_completer;
+
+pub use search_completer::SearchCompleter;

--- a/src/auto_completers/search_completer.rs
+++ b/src/auto_completers/search_completer.rs
@@ -1,0 +1,32 @@
+/// Provides suggestions for searches.
+use crate::auto_completer::AutoCompleter;
+use crate::data::Data;
+
+/// Provides suggestions for searches.
+pub struct SearchCompleter {}
+
+impl SearchCompleter {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl AutoCompleter<String, String> for SearchCompleter {
+    /// For now, the completion strategy is to suggest the most recent search that starts with the
+    /// partial string.
+    fn complete(&mut self, partial: String) -> Option<String> {
+        // NOTE: We might not want to read data from disk each call because this could be slow.
+        let data: Data = Data::read();
+        let mut searches: Vec<String> = data.searcher.history.into();
+
+        // Searches are stored oldest to newest so we want to iterate in reverse.
+        searches.reverse();
+        for search in searches.iter() {
+            if search.starts_with(&partial) {
+                return Some(search.to_string());
+            }
+        }
+
+        None
+    }
+}

--- a/src/color.rs
+++ b/src/color.rs
@@ -14,10 +14,11 @@ const LIGHT_GREY: CrosstermColor = CrosstermColor::Rgb {
 
 pub enum Color {
     Highlight,
-    GrayyedText,
-    LightGrayyedText,
+    GrayedText,
+    LightGrayedText,
     InvertedText,
-    InvertedGrayyedText,
+    InvertedGrayedText,
+    InvertedLightGrayedText,
     InvertedBackground,
     BadRegex,
     NotCompiledRegex,
@@ -27,10 +28,11 @@ impl From<Color> for CrosstermColor {
     fn from(color: Color) -> CrosstermColor {
         match color {
             Color::Highlight => CrosstermColor::Yellow,
-            Color::GrayyedText => DARK_GREY,
-            Color::LightGrayyedText => LIGHT_GREY,
+            Color::GrayedText => DARK_GREY,
+            Color::LightGrayedText => LIGHT_GREY,
             Color::InvertedText => CrosstermColor::Black,
-            Color::InvertedGrayyedText => LIGHT_GREY,
+            Color::InvertedGrayedText => LIGHT_GREY,
+            Color::InvertedLightGrayedText => DARK_GREY,
             Color::InvertedBackground => CrosstermColor::White,
             Color::BadRegex => CrosstermColor::Red,
             Color::NotCompiledRegex => DARK_GREY,

--- a/src/components/browser/contents.rs
+++ b/src/components/browser/contents.rs
@@ -68,7 +68,7 @@ impl Component<Props, Event, Effect> for Contents {
                 yarn.color(Color::InvertedText.into());
                 yarn.background(Color::Highlight.into());
             } else if hidden {
-                yarn.color(Color::LightGrayyedText.into());
+                yarn.color(Color::LightGrayedText.into());
             }
             yarn.resize(size.columns);
             yarns.push(yarn);

--- a/src/components/finder/contents.rs
+++ b/src/components/finder/contents.rs
@@ -121,11 +121,11 @@ mod contents {
                         let file_name_start: usize = yarn.len() - entry.file_name().len();
 
                         if self.state.focussed() && Some(row) == self.state.selected() {
-                            yarn.color_before(Color::InvertedGrayyedText.into(), file_name_start);
+                            yarn.color_before(Color::InvertedGrayedText.into(), file_name_start);
                             yarn.color_after(Color::InvertedText.into(), file_name_start);
                             yarn.background(Color::Highlight.into());
                         } else {
-                            yarn.color_before(Color::GrayyedText.into(), file_name_start);
+                            yarn.color_before(Color::GrayedText.into(), file_name_start);
                         }
 
                         yarn.resize(size.columns);

--- a/src/components/searcher/searcher.rs
+++ b/src/components/searcher/searcher.rs
@@ -1,17 +1,20 @@
 mod props {
+    use crate::config::Config;
     use crate::rendering::Size;
 
     use std::path::PathBuf;
 
     pub struct Props {
+        pub config: Config,
         pub directory: PathBuf,
         pub size: Size,
         pub phrase: Option<String>,
     }
 
     impl Props {
-        pub fn new(directory: PathBuf, size: Size, phrase: Option<String>) -> Self {
+        pub fn new(config: Config, directory: PathBuf, size: Size, phrase: Option<String>) -> Self {
             Self {
+                config,
                 directory,
                 size,
                 phrase,
@@ -150,7 +153,9 @@ pub use effect::Effect;
 mod state {
     use super::super::{Contents, ContentsEffect, ContentsEvent, ContentsProps};
     use super::{Action, Effect, Props};
-    use crate::components::common::{Directory, DirectoryProps, Phrase, PhraseEvent};
+    use crate::auto_completer::AutoCompleter;
+    use crate::auto_completers::SearchCompleter;
+    use crate::components::common::{Directory, DirectoryProps, Phrase, PhraseEvent, PhraseProps};
     use crate::programs::VimArgs;
     use crate::rendering::Size;
     use crate::{Component, Stateful};
@@ -222,10 +227,13 @@ mod state {
             let directory_props = DirectoryProps::new(props.directory.clone());
             let directory = Directory::new(directory_props);
 
-            let phrase = Phrase::default();
+            let search_completer: Option<Box<dyn AutoCompleter<String, String>>> =
+                Some(Box::new(SearchCompleter::new()));
+            let phrase_props = PhraseProps::new(search_completer);
+            let phrase = Phrase::new(phrase_props);
 
             let contents_size = Size::new(props.size.rows.saturating_sub(2), props.size.columns);
-            let contents_props = ContentsProps::new(props.directory, contents_size);
+            let contents_props = ContentsProps::new(props.config, props.directory, contents_size);
             let contents = Contents::new(contents_props);
 
             let mut state = Self {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,130 @@
+use std::fmt::{Display, Formatter, Result as FormatResult};
+use std::fs::File;
+use std::io::{Error as IOError, ErrorKind as IOErrorKind};
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde_yaml::Error as YamlParseError;
+
+#[derive(Deserialize, Debug, Default, Clone, Eq, PartialEq)]
+pub struct Config {
+    pub searcher: SearcherConfig,
+}
+
+impl Config {
+    /// Return the default path of the file that configuration is loaded from.
+    pub fn default_path() -> ConfigDefaultPathResult {
+        let mut path: PathBuf = match dirs::home_dir() {
+            Some(path) => path,
+            None => {
+                return Err(ConfigDefaultPathError::CannotDetermineHomeDirectory);
+            }
+        };
+        path.push("insh-config.yaml");
+        Ok(path)
+    }
+
+    /// Return the `Config` loaded from the default file if it exists or the default config if the
+    /// file does not exist. If there is an error then return a `ConfigLoadError`.
+    pub fn load() -> ConfigLoadResult {
+        let path: PathBuf = match Self::default_path() {
+            Ok(path) => path,
+            Err(error) => {
+                return Err(ConfigLoadError::ConfigDefaultPathError(error));
+            }
+        };
+
+        let file: File = match File::open(path.clone()) {
+            Ok(file) => file,
+            Err(error) => match error.kind() {
+                IOErrorKind::NotFound => {
+                    return Ok(Config::default());
+                }
+                IOErrorKind::PermissionDenied => {
+                    return Err(ConfigLoadError::PermissionDeniedError(path));
+                }
+                _ => {
+                    return Err(ConfigLoadError::OtherFileReadError { path, error });
+                }
+            },
+        };
+
+        match serde_yaml::from_reader(file) {
+            Ok(config) => Ok(config),
+            Err(error) => Err(ConfigLoadError::ParseError { path, error }),
+        }
+    }
+}
+
+type ConfigDefaultPathResult = Result<PathBuf, ConfigDefaultPathError>;
+
+pub enum ConfigDefaultPathError {
+    CannotDetermineHomeDirectory,
+}
+
+type ConfigLoadResult = Result<Config, ConfigLoadError>;
+
+#[allow(clippy::enum_variant_names)]
+pub enum ConfigLoadError {
+    ConfigDefaultPathError(ConfigDefaultPathError),
+    PermissionDeniedError(PathBuf),
+    OtherFileReadError {
+        path: PathBuf,
+        error: IOError,
+    },
+    ParseError {
+        path: PathBuf,
+        error: YamlParseError,
+    },
+}
+
+impl Display for ConfigLoadError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
+        match self {
+            Self::ConfigDefaultPathError(error) => match error {
+                ConfigDefaultPathError::CannotDetermineHomeDirectory => {
+                    write!(f, "Failed to load the configuration because the home directory could not be determined.")
+                }
+            },
+            Self::PermissionDeniedError(path) => {
+                write!(
+                    f,
+                    "Failed to load the configuration file \"{}\" because permission was denied.",
+                    path.display()
+                )
+            }
+            Self::OtherFileReadError { path, error } => {
+                write!(
+                    f,
+                    "Failed to load the configuration file \"{}\" because of an IO error: {}",
+                    path.display(),
+                    error
+                )
+            }
+            Self::ParseError { path, error } => {
+                write!(
+                    f,
+                    "Failed to parse the configuration file \"{}\": {}",
+                    path.display(),
+                    error
+                )
+            }
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Default, Clone, Eq, PartialEq)]
+pub struct SearcherConfig {
+    pub history: SearcherHistoryConfig,
+}
+
+#[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct SearcherHistoryConfig {
+    pub length: usize,
+}
+
+impl Default for SearcherHistoryConfig {
+    fn default() -> Self {
+        Self { length: 1000 }
+    }
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,212 @@
+use std::collections::VecDeque;
+use std::fs::{DirBuilder, File, OpenOptions};
+use std::io::ErrorKind as IOErrorKind;
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
+use std::path::PathBuf;
+
+use fslock::LockFile;
+
+use serde::{Deserialize, Serialize};
+
+/// The permissions to use for the data directory and files in it.
+static INSH_DIRECTORY_PERMISSIONS: u32 = 0o700; // rwx --- ---
+static INSH_FILES_PERMISSIONS: u32 = 0o600; // rw- --- ---
+
+lazy_static! {
+
+    /// The directory that the data file is stored in for a user.
+    static ref INSH_DIRECTORY: Option<PathBuf> = {
+        let home: Option<PathBuf> = dirs::home_dir();
+        match home {
+            Some(home) => {
+                #[allow(clippy::redundant_clone)]
+                let mut path = home.clone();
+                path.push(".insh");
+                Some(path)
+            },
+            None => None,
+        }
+    };
+
+    /// The file path for user data. This is `None` if the home directory of the user cannot be
+    /// determined.
+    static ref PATH: Option<PathBuf> = {
+        let home: Option<PathBuf> = dirs::home_dir();
+        match home {
+            Some(home) => {
+                #[allow(clippy::redundant_clone)]
+                let mut path = home.clone();
+                path.push(".insh/data.yaml");
+                Some(path)
+            },
+            None => None,
+        }
+    };
+
+    /// The file path for the lock file on data. This is `None` if the home directory of the user
+    /// cannot be determined.
+    static ref LOCK_FILE_PATH: Option<PathBuf> = {
+        let home: Option<PathBuf> = dirs::home_dir();
+        match home {
+            Some(home) => {
+                #[allow(clippy::redundant_clone)]
+                let mut path = home.clone();
+                path.push(".insh/data.lock");
+                Some(path)
+            },
+            None => None,
+        }
+    };
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Data {
+    #[serde(skip, default = "get_lock_file")]
+    lock: LockFile,
+
+    pub searcher: SearcherData,
+}
+
+impl Default for Data {
+    fn default() -> Self {
+        Self {
+            lock: get_lock_file(),
+            searcher: SearcherData::default(),
+        }
+    }
+}
+
+/// Get the lock file object.
+fn get_lock_file() -> LockFile {
+    ensure_insh_directory_exists();
+
+    let lock_file_path: PathBuf = match &*LOCK_FILE_PATH {
+        Some(path) => path.to_path_buf(),
+        None => {
+            panic!("Cannot get the data file lock because the home directory of the user cannot be determined.");
+        }
+    };
+
+    // NOTE: The lock file is created w/ the permissions -rw-r--r--. It would be nice if we could
+    // change tell it to create it w/ -rw------- but it doesn't look like it has that capability.
+    // We could change the perms after it is created but this is probably fine for now.
+    let mut lock_file = LockFile::open(&lock_file_path).unwrap();
+    lock_file.lock_with_pid().unwrap();
+    lock_file
+}
+
+/// Ensure that the Insh directory used for storing data exists.
+fn ensure_insh_directory_exists() {
+    match &*INSH_DIRECTORY {
+        Some(insh_directory) => {
+            if !insh_directory.exists() {
+                DirBuilder::new()
+                    .mode(INSH_DIRECTORY_PERMISSIONS)
+                    .create(insh_directory)
+                    .expect("Failed to create the insh directory.");
+            }
+        }
+        None => {
+            panic!("Cannot create the Insh directory because the home directory of the user cannot be determined.");
+        }
+    }
+}
+
+impl Data {
+    #[allow(dead_code)]
+    pub fn acquire(&mut self) {
+        self.lock = get_lock_file();
+    }
+
+    fn has_lock(&self) -> bool {
+        self.lock.owns_lock()
+    }
+
+    pub fn release(&mut self) {
+        self.lock.unlock().unwrap();
+    }
+
+    /// Read the data from the file system. If the data file does not exist, then return the default
+    /// data.
+    ///
+    /// This also aquires a lock on the data.
+    pub fn read() -> Self {
+        let path: PathBuf = match &*PATH {
+            Some(path) => path.to_path_buf(),
+            None => {
+                panic!();
+                // return Self::default();
+            }
+        };
+
+        let file: File = match File::open(path) {
+            Ok(file) => file,
+            Err(error) => match error.kind() {
+                IOErrorKind::NotFound => {
+                    return Data::default();
+                }
+                error => {
+                    panic!(
+                        "Could not read stored data. Encounted the following error: {}",
+                        error
+                    );
+                }
+            },
+        };
+
+        let data: Data = match serde_yaml::from_reader(file) {
+            Ok(data) => data,
+            Err(error) => {
+                panic!(
+                    "Could not parse stored data. Encounted the following error: {}",
+                    error
+                );
+            }
+        };
+
+        data
+    }
+
+    /// Serialize and write the data to a file.
+    ///
+    /// For now, the data is written as YAML, but speed and size comparisons should be made for
+    /// different data formats at some point.
+    pub fn write(&mut self) {
+        if !self.has_lock() {
+            panic!("Cannot write the data because it is not locked.");
+        }
+
+        let path: PathBuf = match &*PATH {
+            Some(path) => path.to_path_buf(),
+            None => {
+                panic!("Cannot write the data because the path cannot be determined.");
+            }
+        };
+
+        let file: File = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .mode(INSH_FILES_PERMISSIONS)
+            .open(path)
+            .expect("Cannot write persistent data because the data file could not be opened or created.");
+
+        serde_yaml::to_writer(file, self).unwrap();
+    }
+}
+
+/// Data about searching for text in files.
+#[derive(Serialize, Deserialize, Default)]
+pub struct SearcherData {
+    /// The history of searches from oldest to newest.
+    pub history: VecDeque<String>,
+}
+
+impl SearcherData {
+    /// Add an entry to the history.
+    pub fn add_to_history(&mut self, phrase: &str, max_length: usize) {
+        self.history.push_back(phrase.to_string());
+        if self.history.len() > max_length {
+            self.history.pop_front();
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,20 @@
 #![allow(clippy::module_inception)]
 #![allow(clippy::needless_return)]
 
+#[macro_use]
+extern crate lazy_static;
+
 mod app;
 mod args;
+mod auto_completer;
+mod auto_completers;
 mod clipboard;
 mod color;
 mod component;
 mod components;
+mod config;
 mod current_dir;
+mod data;
 mod path_finder;
 mod phrase_searcher;
 mod program;
@@ -22,16 +29,27 @@ use crate::app::App;
 use crate::args::Args;
 use crate::component::Component;
 use crate::components::{Insh, InshProps};
+use crate::config::Config;
 use crate::stateful::Stateful;
 use crate::system_effect::SystemEffect;
 
 use clap::Parser;
 
+use std::process::exit;
+
 fn main() {
     let args: Args = Args::parse();
     let starting_effects: Option<Vec<SystemEffect>> = args.starting_effects();
 
-    let insh_props: InshProps = InshProps::from(args);
+    let config: Config = match Config::load() {
+        Ok(config) => config,
+        Err(error) => {
+            println!("{}", error);
+            exit(1);
+        }
+    };
+
+    let insh_props: InshProps = InshProps::from((args, config));
 
     let mut app: App = App::new();
     let mut root = Insh::new(insh_props);

--- a/src/rendering/yarn.rs
+++ b/src/rendering/yarn.rs
@@ -76,16 +76,14 @@ impl Yarn {
         let len_before: usize = self.len();
         self.characters.extend(other.characters);
 
-        if self.colors.len() < len_before {
-            if !other.colors.is_empty() {
-                self.colors.resize(len_before, None);
-                self.colors.extend(other.colors);
-            }
+        if !other.colors.is_empty() {
+            self.colors.resize(len_before, None);
+            self.colors.extend(other.colors);
+        }
 
-            if !other.backgrounds.is_empty() {
-                self.backgrounds.resize(len_before, None);
-                self.backgrounds.extend(other.backgrounds);
-            }
+        if !other.backgrounds.is_empty() {
+            self.backgrounds.resize(len_before, None);
+            self.backgrounds.extend(other.backgrounds);
         }
 
         self


### PR DESCRIPTION
Add storage of searches to `~/.insh/data.yaml` and add auto complete suggestions to the phrase component. Right now the auto complete for the searcher just suggests the most recent search that starts with the same string that has currently been inputted. The `<Tab>` key can be used to fill in the suggestion.