### PR TITLE
Add logging

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -17,6 +17,19 @@ jobs:
 
       - name: Check that it compiles
         run: ./cargo-scripts/check
+
+  check-with-logging-feature:
+    name: Check (with logging feature)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Rust
+        run: curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+      - name: Check that it compiles with the logging feature enabled
+        run: ./scripts/check-with-logging-feature
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.14
+- Add logging as a complile feature.
+
 # 0.3.13
 - Fix the crash in the browser when permission is denied or the directory cannot be read for some other
 reason.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +191,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "flexi_logger"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a12e3b5a8775259ee83ac38aea8cdf9c3a1667c02178d207378c0837808fa9"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "glob",
+ "lazy_static",
+ "log",
+ "regex",
+ "rustversion",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "fslock"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +227,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"
@@ -235,15 +267,17 @@ dependencies = [
 
 [[package]]
 name = "insh"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "clap",
  "copypasta",
  "crossterm",
  "dirs",
+ "flexi_logger",
  "fslock",
  "itertools",
  "lazy_static",
+ "log",
  "regex",
  "serde",
  "serde_yaml",
@@ -306,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
@@ -415,6 +449,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -574,6 +617,12 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "ryu"
@@ -763,6 +812,24 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "insh"
-version = "0.3.13"
+version = "0.3.14"
 edition = "2021"
+
+[features]
+# Explicitly, the default features are none.
+default = []
+
+# The logging feature enables logging which is helpful for development.
+logging = ["dep:log", "dep:flexi_logger"]
 
 [dependencies]
 crossterm = "0.23.0"
@@ -24,6 +31,10 @@ serde_yaml = "0.9.10"
 
 # Used for declaring lazily evaluated static values.
 lazy_static = "1.4.0"
+
+# Used for logging. (These dependencies are only included if the logging features is enabled.)
+log = { version = "0.4.17", optional = true }
+flexi_logger = { version = "0.23.3", optional = true }
 
 [dev-dependencies]
 test-case = "2.0.0"

--- a/notes/logging.md
+++ b/notes/logging.md
@@ -1,0 +1,15 @@
+# Logging
+
+Logging for debug purposes can be enabled by building with the "logging" feature.
+
+It is recommended to use a unix named pipe for the logs. One way to do this is with the tool
+`socat` (`brew install socat`). Use `socat` to create a named pipe and have it echo the contents to
+stdout with the command:
+
+```
+socat -u pipe:<log-file>,mode=700 -
+```
+
+where `<log-file>` is the file path for the named pipe (e.g. `/tmp/insh-pipe`). 
+
+Then run `Insh` with the argument `--log-file <log-file>`.

--- a/scripts/all
+++ b/scripts/all
@@ -5,4 +5,7 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 "${REPO_ROOT}/cargo-scripts/all"
+
+"${REPO_ROOT}/scripts/check-with-logging-feature"
+
 "${REPO_ROOT}/scripts/lint-arbsego"

--- a/scripts/check-with-logging-feature
+++ b/scripts/check-with-logging-feature
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+cd "${REPO_ROOT}"
+
+cargo check --features logging

--- a/src/app.rs
+++ b/src/app.rs
@@ -33,6 +33,9 @@ impl App {
     ) {
         self.set_up();
 
+        #[cfg(feature = "logging")]
+        log::info!("Running.");
+
         if let Some(effects) = starting_effects {
             for effect in effects {
                 match effect {

--- a/src/args.rs
+++ b/src/args.rs
@@ -9,8 +9,13 @@ use clap::{Parser, Subcommand};
 #[clap(author, version, about)]
 pub struct Args {
     /// Starting directory to run in
-    #[clap(short, long)]
+    #[clap(short, long, display_order = 0)]
     directory: Option<PathBuf>,
+
+    /// Unix socket to write logs to
+    #[cfg(feature = "logging")]
+    #[clap(long = "log-file", display_order = 1)]
+    pub log_file_path: Option<PathBuf>,
 
     #[clap(subcommand)]
     command: Option<Command>,
@@ -19,6 +24,11 @@ pub struct Args {
 impl Args {
     pub fn directory(&self) -> &Option<PathBuf> {
         &self.directory
+    }
+
+    #[cfg(feature = "logging")]
+    pub fn log_file_path(&self) -> &Option<PathBuf> {
+        &self.log_file_path
     }
 
     pub fn command(&self) -> &Option<Command> {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,31 @@
+/// Logging for debug purposes.
+use std::fmt::{Display, Error as FormatError, Formatter};
+use std::path::PathBuf;
+
+use flexi_logger::writers::FileLogWriter;
+use flexi_logger::{FileSpec, LogSpecification, Logger, LoggerHandle};
+
+/// Configure logging.
+pub fn configure_logging(path: PathBuf) -> ConfigureLoggingResult {
+    let log_specification: LogSpecification = LogSpecification::info();
+    let mut logger = Logger::with(log_specification);
+
+    let file_log_writer = FileLogWriter::builder(FileSpec::try_from(path).unwrap())
+        .try_build()
+        .unwrap();
+    logger = logger.log_to_writer(Box::new(file_log_writer));
+
+    let logger_handle = logger.start().unwrap();
+
+    Ok(logger_handle)
+}
+
+pub type ConfigureLoggingResult = Result<LoggerHandle, ConfigureLoggingError>;
+
+pub enum ConfigureLoggingError {}
+
+impl Display for ConfigureLoggingError {
+    fn fmt(&self, _formatter: &mut Formatter<'_>) -> Result<(), FormatError> {
+        todo!();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,8 @@ mod components;
 mod config;
 mod current_dir;
 mod data;
+#[cfg(feature = "logging")]
+mod logging;
 mod path_finder;
 mod phrase_searcher;
 mod program;
@@ -30,15 +32,35 @@ use crate::args::Args;
 use crate::component::Component;
 use crate::components::{Insh, InshProps};
 use crate::config::Config;
+#[cfg(feature = "logging")]
+use crate::logging::{configure_logging, ConfigureLoggingResult};
 use crate::stateful::Stateful;
 use crate::system_effect::SystemEffect;
 
 use clap::Parser;
+#[cfg(feature = "logging")]
+use flexi_logger::LoggerHandle;
 
 use std::process::exit;
 
 fn main() {
     let args: Args = Args::parse();
+
+    #[cfg(feature = "logging")]
+    let _logger_handle: LoggerHandle;
+    #[cfg(feature = "logging")]
+    if let Some(log_file_path) = args.log_file_path() {
+        let configure_logging_result: ConfigureLoggingResult =
+            configure_logging(log_file_path.to_path_buf());
+        _logger_handle = match configure_logging_result {
+            Ok(_logger_handle) => _logger_handle,
+            Err(error) => {
+                println!("{}", error);
+                exit(1);
+            }
+        }
+    }
+
     let starting_effects: Option<Vec<SystemEffect>> = args.starting_effects();
 
     let config: Config = match Config::load() {


### PR DESCRIPTION
Add the ability to log to a named pipe (or a normal file). This is behind the compile time feature "logging". There are some instructions for how to use the tool `socat` to set up a named pipe in `notes/logging.md`.