### PR TITLE
Fix tabs in the searcher

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -58,19 +58,43 @@ jobs:
         run: curl https://sh.rustup.rs -sSf | sh -s -- -y
 
       - name: Install Brew
-        run: NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        run: |
+          NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+          # Run the commands that Brew recommends for setting itself up.
+          echo '# Set PATH, MANPATH, etc., for Homebrew.' >> ~/.bash_profile
+          echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> ~/.bash_profile
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+
+          # Turn off Brew usage analytics.
+          brew analytics off
 
       - name: Install yq
-        run: brew install yq
+        run: |
+          # Make sure brew is setup.
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+
+          # Install yq using brew.
+          brew install yq
 
       - name: Install Arbsego
         run: |-
+          # Make sure brew is setup.
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+
+          # Get the version of Arbsego to use.
           ARBSEGO_VERSION="$(yq '.arbsego.version' < truth.yaml)"
+  
+          # Install Arbsego using cargo.
           cargo install --git https://github.com/AustinScola/arbsego.git --tag "v${ARBSEGO_VERSION}"
 
-      # TODO: Pass BOOTSTRAP=1 to lint-arbsego and have it handle all of the above installations.
       - name: Lint using Arbsego
-        run: ./scripts/lint-arbsego
+        run: |
+          # Make sure brew is setup.
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+
+          # Lint using Arbsego.
+          ./scripts/lint-arbsego
 
   format:
     name: Format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.15
+- Fix the displaying of tabs in the Searcher contents and add a configuration option
+`general.tab_width` to enable changing the width that is used for tabs.
+
 # 0.3.14
 - Add logging as a complile feature.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "insh"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "clap",
  "copypasta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insh"
-version = "0.3.14"
+version = "0.3.15"
 edition = "2021"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -98,4 +98,5 @@ The commands for the input bar are the same as those for the Finder.
 Insh can be configured by the file `~/.insh-config.yaml`.
 
 ### Options
-`searcher.history.length` (int): The number of searches to store.
+`general.tab_width` (usize): The width of the `<Tab>` character.
+`searcher.history.length` (usize): The number of searches to store.

--- a/src/components/insh.rs
+++ b/src/components/insh.rs
@@ -234,8 +234,9 @@ impl From<Props> for State {
             Start::Browser => Self {
                 mode: Mode::Browse,
                 browser,
+                finder: None,
+                searcher: None,
                 config: props.config().clone(),
-                ..Default::default()
             },
             Start::Finder { phrase } => {
                 let finder_props = FinderProps::new(directory, size, phrase.clone());
@@ -244,8 +245,8 @@ impl From<Props> for State {
                     mode: Mode::Finder,
                     browser,
                     finder,
+                    searcher: None,
                     config: props.config().clone(),
-                    ..Default::default()
                 }
             }
             Start::Searcher { phrase } => {
@@ -255,15 +256,17 @@ impl From<Props> for State {
                 Self {
                     mode: Mode::Searcher,
                     browser,
+                    finder: None,
                     searcher,
                     config: props.config().clone(),
-                    ..Default::default()
                 }
             }
             Start::Nothing => Self {
                 mode: Mode::Nothing,
+                browser: None,
+                finder: None,
+                searcher: None,
                 config: props.config().clone(),
-                ..Default::default()
             },
         }
     }
@@ -304,27 +307,6 @@ impl State {
     fn quit_searcher(&mut self) -> Option<SystemEffect> {
         self.mode = Mode::Browse;
         None
-    }
-}
-
-impl Default for State {
-    fn default() -> Self {
-        let mode: Mode = Mode::default();
-
-        let size: Size = Size::from(terminal::size().unwrap());
-
-        let directory: PathBuf = current_dir::current_dir();
-        let browser: Option<Browser> = Some(Browser::new(BrowserProps::new(directory, size, None)));
-        let finder: Option<Finder> = None;
-        let searcher: Option<Searcher> = None;
-
-        State {
-            mode,
-            browser,
-            finder,
-            searcher,
-            config: Config::default(),
-        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,130 +1,188 @@
-use std::fmt::{Display, Formatter, Result as FormatResult};
-use std::fs::File;
-use std::io::{Error as IOError, ErrorKind as IOErrorKind};
-use std::path::PathBuf;
+mod config {
+    use super::{GeneralConfig, SearcherConfig};
 
-use serde::Deserialize;
-use serde_yaml::Error as YamlParseError;
+    use std::fmt::{Display, Formatter, Result as FormatResult};
+    use std::fs::File;
+    use std::io::{Error as IOError, ErrorKind as IOErrorKind};
+    use std::path::PathBuf;
 
-#[derive(Deserialize, Debug, Default, Clone, Eq, PartialEq)]
-pub struct Config {
-    pub searcher: SearcherConfig,
-}
+    use serde::Deserialize;
+    use serde_yaml::Error as YamlParseError;
 
-impl Config {
-    /// Return the default path of the file that configuration is loaded from.
-    pub fn default_path() -> ConfigDefaultPathResult {
-        let mut path: PathBuf = match dirs::home_dir() {
-            Some(path) => path,
-            None => {
-                return Err(ConfigDefaultPathError::CannotDetermineHomeDirectory);
-            }
-        };
-        path.push(".insh-config.yaml");
-        Ok(path)
+    #[derive(Deserialize, Debug, Default, Clone, Eq, PartialEq)]
+    pub struct Config {
+        general: GeneralConfig,
+        searcher: SearcherConfig,
     }
 
-    /// Return the `Config` loaded from the default file if it exists or the default config if the
-    /// file does not exist. If there is an error then return a `ConfigLoadError`.
-    pub fn load() -> ConfigLoadResult {
-        let path: PathBuf = match Self::default_path() {
-            Ok(path) => path,
-            Err(error) => {
-                return Err(ConfigLoadError::ConfigDefaultPathError(error));
+    impl Config {
+        /// Return the default path of the file that configuration is loaded from.
+        pub fn default_path() -> ConfigDefaultPathResult {
+            let mut path: PathBuf = match dirs::home_dir() {
+                Some(path) => path,
+                None => {
+                    return Err(ConfigDefaultPathError::CannotDetermineHomeDirectory);
+                }
+            };
+            path.push(".insh-config.yaml");
+            Ok(path)
+        }
+
+        /// Return the `Config` loaded from the default file if it exists or the default config if the
+        /// file does not exist. If there is an error then return a `ConfigLoadError`.
+        pub fn load() -> ConfigLoadResult {
+            let path: PathBuf = match Self::default_path() {
+                Ok(path) => path,
+                Err(error) => {
+                    return Err(ConfigLoadError::ConfigDefaultPathError(error));
+                }
+            };
+
+            let file: File = match File::open(path.clone()) {
+                Ok(file) => file,
+                Err(error) => match error.kind() {
+                    IOErrorKind::NotFound => {
+                        return Ok(Config::default());
+                    }
+                    IOErrorKind::PermissionDenied => {
+                        return Err(ConfigLoadError::PermissionDeniedError(path));
+                    }
+                    _ => {
+                        return Err(ConfigLoadError::OtherFileReadError { path, error });
+                    }
+                },
+            };
+
+            match serde_yaml::from_reader(file) {
+                Ok(config) => Ok(config),
+                Err(error) => Err(ConfigLoadError::ParseError { path, error }),
             }
-        };
+        }
 
-        let file: File = match File::open(path.clone()) {
-            Ok(file) => file,
-            Err(error) => match error.kind() {
-                IOErrorKind::NotFound => {
-                    return Ok(Config::default());
-                }
-                IOErrorKind::PermissionDenied => {
-                    return Err(ConfigLoadError::PermissionDeniedError(path));
-                }
-                _ => {
-                    return Err(ConfigLoadError::OtherFileReadError { path, error });
-                }
-            },
-        };
+        /// Return the general configuration.
+        pub fn general(&self) -> &GeneralConfig {
+            &self.general
+        }
 
-        match serde_yaml::from_reader(file) {
-            Ok(config) => Ok(config),
-            Err(error) => Err(ConfigLoadError::ParseError { path, error }),
+        /// Return the searcher configuration.
+        pub fn searcher(&self) -> &SearcherConfig {
+            &self.searcher
+        }
+    }
+
+    type ConfigDefaultPathResult = Result<PathBuf, ConfigDefaultPathError>;
+
+    pub enum ConfigDefaultPathError {
+        CannotDetermineHomeDirectory,
+    }
+
+    type ConfigLoadResult = Result<Config, ConfigLoadError>;
+
+    #[allow(clippy::enum_variant_names)]
+    pub enum ConfigLoadError {
+        ConfigDefaultPathError(ConfigDefaultPathError),
+        PermissionDeniedError(PathBuf),
+        OtherFileReadError {
+            path: PathBuf,
+            error: IOError,
+        },
+        ParseError {
+            path: PathBuf,
+            error: YamlParseError,
+        },
+    }
+
+    impl Display for ConfigLoadError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
+            match self {
+                Self::ConfigDefaultPathError(error) => match error {
+                    ConfigDefaultPathError::CannotDetermineHomeDirectory => {
+                        write!(f, "Failed to load the configuration because the home directory could not be determined.")
+                    }
+                },
+                Self::PermissionDeniedError(path) => {
+                    write!(
+                        f,
+                        "Failed to load the configuration file \"{}\" because permission was denied.",
+                        path.display()
+                    )
+                }
+                Self::OtherFileReadError { path, error } => {
+                    write!(
+                        f,
+                        "Failed to load the configuration file \"{}\" because of an IO error: {}",
+                        path.display(),
+                        error
+                    )
+                }
+                Self::ParseError { path, error } => {
+                    write!(
+                        f,
+                        "Failed to parse the configuration file \"{}\": {}",
+                        path.display(),
+                        error
+                    )
+                }
+            }
         }
     }
 }
+pub use config::{Config, ConfigLoadError};
 
-type ConfigDefaultPathResult = Result<PathBuf, ConfigDefaultPathError>;
+mod general {
+    use serde::Deserialize;
 
-pub enum ConfigDefaultPathError {
-    CannotDetermineHomeDirectory,
-}
+    #[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
+    pub struct GeneralConfig {
+        tab_width: usize,
+    }
 
-type ConfigLoadResult = Result<Config, ConfigLoadError>;
+    impl Default for GeneralConfig {
+        fn default() -> Self {
+            Self { tab_width: 4 }
+        }
+    }
 
-#[allow(clippy::enum_variant_names)]
-pub enum ConfigLoadError {
-    ConfigDefaultPathError(ConfigDefaultPathError),
-    PermissionDeniedError(PathBuf),
-    OtherFileReadError {
-        path: PathBuf,
-        error: IOError,
-    },
-    ParseError {
-        path: PathBuf,
-        error: YamlParseError,
-    },
-}
-
-impl Display for ConfigLoadError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
-        match self {
-            Self::ConfigDefaultPathError(error) => match error {
-                ConfigDefaultPathError::CannotDetermineHomeDirectory => {
-                    write!(f, "Failed to load the configuration because the home directory could not be determined.")
-                }
-            },
-            Self::PermissionDeniedError(path) => {
-                write!(
-                    f,
-                    "Failed to load the configuration file \"{}\" because permission was denied.",
-                    path.display()
-                )
-            }
-            Self::OtherFileReadError { path, error } => {
-                write!(
-                    f,
-                    "Failed to load the configuration file \"{}\" because of an IO error: {}",
-                    path.display(),
-                    error
-                )
-            }
-            Self::ParseError { path, error } => {
-                write!(
-                    f,
-                    "Failed to parse the configuration file \"{}\": {}",
-                    path.display(),
-                    error
-                )
-            }
+    impl GeneralConfig {
+        pub fn tab_width(&self) -> usize {
+            self.tab_width
         }
     }
 }
+pub use general::GeneralConfig;
 
-#[derive(Deserialize, Debug, Default, Clone, Eq, PartialEq)]
-pub struct SearcherConfig {
-    pub history: SearcherHistoryConfig,
-}
+mod search {
+    use serde::Deserialize;
 
-#[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
-pub struct SearcherHistoryConfig {
-    pub length: usize,
-}
+    #[derive(Deserialize, Debug, Default, Clone, Eq, PartialEq)]
+    pub struct SearcherConfig {
+        history: SearcherHistoryConfig,
+    }
 
-impl Default for SearcherHistoryConfig {
-    fn default() -> Self {
-        Self { length: 1000 }
+    impl SearcherConfig {
+        /// Return the searcher history configuration.
+        pub fn history(&self) -> &SearcherHistoryConfig {
+            &self.history
+        }
+    }
+
+    #[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
+    pub struct SearcherHistoryConfig {
+        /// The maximum length of the searcher history.
+        length: usize,
+    }
+
+    impl Default for SearcherHistoryConfig {
+        fn default() -> Self {
+            Self { length: 1000 }
+        }
+    }
+
+    impl SearcherHistoryConfig {
+        /// Return the maximum length of the searcher history.
+        pub fn length(&self) -> usize {
+            self.length
+        }
     }
 }
+pub use search::SearcherConfig;

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -1,4 +1,4 @@
-/// String helper methods.
+/// Extentioned functionality for `std::string::String` provided via extension traits.
 
 /// Return the `strings` joined together using commas, (an Oxoford comma if necessary), and the
 /// `conjuction`.
@@ -51,3 +51,71 @@ mod tests {
         assert_eq!(result, expected_result);
     }
 }
+
+mod detab {
+    pub trait DetabExt {
+        fn detab(&self, tab_width: usize) -> String;
+    }
+
+    impl DetabExt for String {
+        fn detab(&self, tab_width: usize) -> String {
+            self.as_str().detab(tab_width)
+        }
+    }
+
+    impl DetabExt for &str {
+        fn detab(&self, tab_width: usize) -> String {
+            // If the string is empty, then the result is also empty.
+            if self.is_empty() {
+                return String::new();
+            }
+
+            // The resuling string will be at least as long as the input string, so reserve the
+            // capacity for that many characters.
+            let mut result: String = String::with_capacity(self.len());
+
+            let mut counter: usize = 0;
+            for character in self.chars() {
+                match character {
+                    '\t' => {
+                        let number_of_spaces = tab_width - counter;
+                        result.push_str(&(" ".repeat(number_of_spaces)));
+
+                        counter = 0;
+                    }
+                    _ => {
+                        result.push(character);
+
+                        counter += 1;
+                        if counter == tab_width {
+                            counter = 0;
+                        }
+                    }
+                }
+            }
+
+            result
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        use test_case::test_case;
+
+        #[test_case("", 4, ""; "an empty string")]
+        #[test_case("\t", 4, "    "; "just one tab")]
+        #[test_case("\t\t\tfoo", 4, "            foo"; "a couple tabs followed by some text")]
+        #[test_case("\tf\t", 4, "    f   "; "a tab, a character, then a tab")]
+        #[test_case("\tfoo\t", 4, "    foo "; "a tab, a couple characters, then a tab")]
+        #[test_case("\tfoo\tbar", 4, "    foo bar"; "a tab, a couple characters, then a tab, then some more characters")]
+        #[test_case("\ttoad\t", 4, "    toad    "; "a tab, some characters the same width as a tab, then a tab")]
+        fn test_detab(string: &str, tab_width: usize, expected: &str) {
+            let result: String = string.detab(tab_width);
+
+            assert_eq!(result, expected)
+        }
+    }
+}
+pub use detab::DetabExt;


### PR DESCRIPTION
Fix the displaying of tabs in the line contents of the searcher. They were seriously messing up the output because they were being printed directly. Instead, replace them with spaces. The number of spaces is configurable via the `general.tab_width` setting. Note that it isn't as simple as a find and replace because tabbing actually aligns the next input with a column that is a multiple of the tab width.