### PR TITLE
Add log levels control

### DIFF
--- a/notes/logging.md
+++ b/notes/logging.md
@@ -4,12 +4,32 @@ Logging for debug purposes can be enabled by building with the "logging" feature
 
 It is recommended to use a unix named pipe for the logs. One way to do this is with the tool
 `socat` (`brew install socat`). Use `socat` to create a named pipe and have it echo the contents to
-stdout with the command:
+stdout with the command `socat -u pipe:<log-file>,mode=700 -` where `<log-file>` is the file path
+for the named pipe (e.g. `/tmp/insh-log`). 
 
+For example:
 ```
-socat -u pipe:<log-file>,mode=700 -
+socat -u pipe:/tmp/insh-log,mode=700 -
 ```
-
-where `<log-file>` is the file path for the named pipe (e.g. `/tmp/insh-pipe`). 
 
 Then run `Insh` with the argument `--log-file <log-file>`.
+
+For example:
+```
+cargo run --features logging -- --log-file /tmp/insh-log
+```
+
+## Log Levels
+
+The overall log level can be controlled with the `--log-level` argument and log levels for
+individual modules can be controlled with `--module-log-level` arguments. Each module log
+level argument is of the form `<module-name>=<log-level>`.
+
+Example:
+```
+cargo run \
+    --features logging -- \
+    --log-file /tmp/insh-log \
+    --log-level error \
+    --module-log-level insh::auto_completers::search_completer=debug
+```

--- a/src/auto_completers/search_completer.rs
+++ b/src/auto_completers/search_completer.rs
@@ -2,6 +2,9 @@
 use crate::auto_completer::AutoCompleter;
 use crate::data::Data;
 
+#[cfg(feature = "logging")]
+use std::time::Instant;
+
 /// Provides suggestions for searches.
 pub struct SearchCompleter {}
 
@@ -15,6 +18,9 @@ impl AutoCompleter<String, String> for SearchCompleter {
     /// For now, the completion strategy is to suggest the most recent search that starts with the
     /// partial string.
     fn complete(&mut self, partial: String) -> Option<String> {
+        #[cfg(feature = "logging")]
+        let start = Instant::now();
+
         // NOTE: We might not want to read data from disk each call because this could be slow.
         let data: Data = Data::read();
         let mut searches: Vec<String> = data.searcher.history.into();
@@ -23,6 +29,12 @@ impl AutoCompleter<String, String> for SearchCompleter {
         searches.reverse();
         for search in searches.iter() {
             if search.starts_with(&partial) {
+                #[cfg(feature = "logging")]
+                {
+                    let duration = start.elapsed();
+                    log::debug!("Found search completion in {}ms.", duration.as_millis());
+                }
+
                 return Some(search.to_string());
             }
         }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -6,8 +6,10 @@ use flexi_logger::writers::FileLogWriter;
 use flexi_logger::{FileSpec, LogSpecification, Logger, LoggerHandle};
 
 /// Configure logging.
-pub fn configure_logging(path: PathBuf) -> ConfigureLoggingResult {
-    let log_specification: LogSpecification = LogSpecification::info();
+pub fn configure_logging(
+    path: PathBuf,
+    log_specification: LogSpecification,
+) -> ConfigureLoggingResult {
     let mut logger = Logger::with(log_specification);
 
     let file_log_writer = FileLogWriter::builder(FileSpec::try_from(path).unwrap())

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
     #[cfg(feature = "logging")]
     if let Some(log_file_path) = args.log_file_path() {
         let configure_logging_result: ConfigureLoggingResult =
-            configure_logging(log_file_path.to_path_buf());
+            configure_logging(log_file_path.to_path_buf(), args.log_specification());
         _logger_handle = match configure_logging_result {
             Ok(_logger_handle) => _logger_handle,
             Err(error) => {


### PR DESCRIPTION
- Add `--log-level` argument
- Add `--module-log-level` argument (can be used more than once)
- Update logging notes
- Add a log statement for the duration of the search completer