### PR TITLE
Workaround yanking problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.17
+- Fix yanking on Ubuntu 22.04.
+
 # 0.3.16
 - Add a better message to the browser for when the directory does not exist.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "insh"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "clap",
  "copypasta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insh"
-version = "0.3.16"
+version = "0.3.17"
 edition = "2021"
 
 [features]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -14,7 +14,24 @@ impl Clipboard {
 
     /// Set the contents of the clipboard.
     pub fn copy(&mut self, contents: String) {
-        self.context.set_contents(contents).unwrap();
+        #[cfg(feature = "logging")]
+        log::debug!("Setting the clipboard conents to \"{}\"...", contents);
+
+        #[allow(clippy::redundant_clone)]
+        self.context.set_contents(contents.clone()).unwrap();
+
+        // NOTE(ascola): We shouldn't have to do this, but setting contents doesn't seem to work
+        // on my laptop running Ubuntu 22.04 without it?
+        // See https://github.com/alacritty/copypasta/issues/49
+        #[allow(unused_variables)]
+        let actual_contents: String = self.context.get_contents().unwrap();
+
+        #[cfg(feature = "logging")]
+        if actual_contents != contents {
+            log::warn!("Failed to set the clipboard contents.");
+        } else {
+            log::debug!("Successfully set the clipboard contents.");
+        }
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
Yanking didn't seem to be working on a Ubuntu 22.04 machine that I have.

The solution (that I dislike) is that getting the contents after setting them seems to fix it?