### PR TITLE
Add bell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.18
+- Add making of the bell sound for invalid commands. This can be turned off via the configuration
+setting `general.bell`.
+
 # 0.3.17
 - Fix yanking on Ubuntu 22.04.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "insh"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "clap",
  "copypasta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insh"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 
 [features]

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -1,0 +1,21 @@
+/*!
+This module contains an enum [`ASCII`] for different ASCII codes.
+*/
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+/// ASCII codes.
+#[repr(u8)]
+pub enum ASCII {
+    /// The code for a bell.
+    Bell = 0x7,
+}
+
+impl Display for ASCII {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
+        // ASCII is always valid UTF-8 and so we don't need to check it.
+        let bytes = &[*self as u8];
+        let string: &str = unsafe { std::str::from_utf8_unchecked(bytes) };
+
+        write!(formatter, "{}", string)
+    }
+}

--- a/src/components/browser/browser.rs
+++ b/src/components/browser/browser.rs
@@ -73,6 +73,9 @@ impl Component<Props, Event, Effect> for Browser {
                             Some(ContentsEffect::RunBash { directory }) => {
                                 effect = Some(Effect::RunBash { directory });
                             }
+                            Some(ContentsEffect::Bell) => {
+                                effect = Some(Effect::Bell);
+                            }
                             None => {}
                         }
                     }
@@ -145,4 +148,5 @@ pub enum Effect {
     OpenSearcher { directory: PathBuf },
     OpenVim(VimArgs),
     RunBash { directory: PathBuf },
+    Bell,
 }

--- a/src/components/browser/contents.rs
+++ b/src/components/browser/contents.rs
@@ -38,10 +38,10 @@ impl Component<Props, Event, Effect> for Contents {
     }
 
     fn handle(&mut self, event: Event) -> Option<Effect> {
-        if let Some(action) = self.map(event) {
-            return self.state.perform(action);
+        match self.map(event) {
+            Some(action) => self.state.perform(action),
+            None => Some(Effect::Bell),
         }
-        None
     }
 
     fn render(&self, size: Size) -> Fabric {
@@ -518,4 +518,5 @@ pub enum Effect {
     OpenSearcher { directory: PathBuf },
     OpenVim(VimArgs),
     RunBash { directory: PathBuf },
+    Bell,
 }

--- a/src/components/common/phrase.rs
+++ b/src/components/common/phrase.rs
@@ -64,7 +64,7 @@ mod phrase {
                     }) => Some(Action::Enter),
                     CrosstermEvent::Key(KeyEvent {
                         code: KeyCode::Char(character),
-                        ..
+                        modifiers: KeyModifiers::NONE | KeyModifiers::SHIFT,
                     }) => Some(Action::Push {
                         character,
                         auto_completer: &mut self.auto_completer,
@@ -76,7 +76,7 @@ mod phrase {
             if let Some(action) = action {
                 self.state.perform(action)
             } else {
-                None
+                Some(Effect::Bell)
             }
         }
 
@@ -263,6 +263,7 @@ pub use action::Action;
 mod effect {
     pub enum Effect {
         Enter { phrase: String },
+        Bell,
         Quit,
     }
 }

--- a/src/components/finder/contents.rs
+++ b/src/components/finder/contents.rs
@@ -99,7 +99,7 @@ mod contents {
             if let Some(action) = action {
                 self.state.perform(action)
             } else {
-                None
+                Some(Effect::Bell)
             }
         }
 
@@ -476,6 +476,7 @@ mod effect {
             file: Option<PathBuf>,
         },
         OpenVim(VimArgs),
+        Bell,
     }
 }
 pub use effect::Effect;

--- a/src/components/finder/finder.rs
+++ b/src/components/finder/finder.rs
@@ -66,6 +66,9 @@ mod finder {
                                     action = Some(Action::FocusContents);
                                 }
                             }
+                            Some(PhraseEffect::Bell) => {
+                                return Some(Effect::Bell);
+                            }
                             Some(PhraseEffect::Quit) => {
                                 action = Some(Action::Quit);
                             }
@@ -93,6 +96,7 @@ mod finder {
                             Some(ContentsEffect::OpenVim(vim_args)) => {
                                 Some(Effect::OpenVim(vim_args))
                             }
+                            Some(ContentsEffect::Bell) => Some(Effect::Bell),
                             None => None,
                         }
                     }
@@ -256,6 +260,7 @@ mod effect {
             file: Option<PathBuf>,
         },
         OpenVim(VimArgs),
+        Bell,
         Quit,
     }
 }

--- a/src/components/insh.rs
+++ b/src/components/insh.rs
@@ -152,6 +152,9 @@ impl Component<Props, Event, SystemEffect> for Insh {
                         let program = Box::new(Bash::new(directory));
                         return Some(SystemEffect::RunProgram { program });
                     }
+                    Some(BrowserEffect::Bell) => {
+                        action = Some(Action::Bell);
+                    }
                     None => {}
                 }
             }
@@ -169,6 +172,9 @@ impl Component<Props, Event, SystemEffect> for Insh {
                     Some(FinderEffect::Quit) => {
                         action = Some(Action::QuitFinder);
                     }
+                    Some(FinderEffect::Bell) => {
+                        action = Some(Action::Bell);
+                    }
                     None => {}
                 }
             }
@@ -185,6 +191,9 @@ impl Component<Props, Event, SystemEffect> for Insh {
                     Some(SearcherEffect::OpenVim(vim_args)) => {
                         let program = Box::new(Vim::new(vim_args));
                         return Some(SystemEffect::RunProgram { program });
+                    }
+                    Some(SearcherEffect::Bell) => {
+                        action = Some(Action::Bell);
                     }
                     None => {}
                 }
@@ -308,6 +317,15 @@ impl State {
         self.mode = Mode::Browse;
         None
     }
+
+    /// If the bell sound is configured to be made, then return the effect for making the bell
+    /// sound.
+    fn bell(&self) -> Option<SystemEffect> {
+        match self.config.general().bell() {
+            true => Some(SystemEffect::Bell),
+            false => None,
+        }
+    }
 }
 
 impl Stateful<Action, SystemEffect> for State {
@@ -318,6 +336,7 @@ impl Stateful<Action, SystemEffect> for State {
             Action::Search { directory } => self.search(directory),
             Action::QuitFinder => self.quit_finder(),
             Action::QuitSearcher => self.quit_searcher(),
+            Action::Bell => self.bell(),
         }
     }
 }
@@ -346,6 +365,7 @@ enum Action {
     Search {
         directory: PathBuf,
     },
+    Bell,
     QuitFinder,
     QuitSearcher,
 }

--- a/src/components/searcher/contents.rs
+++ b/src/components/searcher/contents.rs
@@ -125,7 +125,7 @@ mod contents {
             if let Some(action) = action {
                 self.state.perform(action)
             } else {
-                None
+                Some(Effect::Bell)
             }
         }
 
@@ -855,6 +855,7 @@ mod effect {
             file: Option<PathBuf>,
         },
         OpenVim(VimArgs),
+        Bell,
     }
 }
 pub use effect::Effect;

--- a/src/components/searcher/searcher.rs
+++ b/src/components/searcher/searcher.rs
@@ -68,6 +68,9 @@ mod searcher {
                                     Some(Action::FocusContents)
                                 }
                             }
+                            Some(PhraseEffect::Bell) => {
+                                return Some(Effect::Bell);
+                            }
                             Some(PhraseEffect::Quit) => Some(Action::Quit),
                             None => None,
                         };
@@ -91,6 +94,9 @@ mod searcher {
                             }
                             Some(ContentsEffect::OpenVim(vim_args)) => {
                                 Some(Action::OpenVim(vim_args))
+                            }
+                            Some(ContentsEffect::Bell) => {
+                                return Some(Effect::Bell);
                             }
                             None => None,
                         };
@@ -144,8 +150,9 @@ mod effect {
             directory: PathBuf,
             file: Option<PathBuf>,
         },
-        Quit,
         OpenVim(VimArgs),
+        Bell,
+        Quit,
     }
 }
 pub use effect::Effect;

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,9 @@ mod config {
 
     #[derive(Deserialize, Debug, Default, Clone, Eq, PartialEq)]
     pub struct Config {
+        #[serde(default)]
         general: GeneralConfig,
+        #[serde(default)]
         searcher: SearcherConfig,
     }
 
@@ -134,18 +136,31 @@ mod general {
 
     #[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
     pub struct GeneralConfig {
+        #[serde(default)]
         tab_width: usize,
+
+        /// Whether the bell sound should be made or not.
+        #[serde(default)]
+        bell: bool,
     }
 
     impl Default for GeneralConfig {
         fn default() -> Self {
-            Self { tab_width: 4 }
+            Self {
+                tab_width: 4,
+                bell: true,
+            }
         }
     }
 
     impl GeneralConfig {
         pub fn tab_width(&self) -> usize {
             self.tab_width
+        }
+
+        /// Return whether the bell sound should be made or not.
+        pub fn bell(&self) -> bool {
+            self.bell
         }
     }
 }
@@ -156,6 +171,7 @@ mod search {
 
     #[derive(Deserialize, Debug, Default, Clone, Eq, PartialEq)]
     pub struct SearcherConfig {
+        #[serde(default)]
         history: SearcherHistoryConfig,
     }
 
@@ -169,6 +185,7 @@ mod search {
     #[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
     pub struct SearcherHistoryConfig {
         /// The maximum length of the searcher history.
+        #[serde(default)]
         length: usize,
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ extern crate lazy_static;
 
 mod app;
 mod args;
+mod ascii;
 mod auto_completer;
 mod auto_completers;
 mod clipboard;

--- a/src/system_effect.rs
+++ b/src/system_effect.rs
@@ -5,11 +5,15 @@ use crate::program::Program;
 
 /// A side-effect that components can emit which the application framework will handle.
 pub enum SystemEffect {
-    /// Exit Insh.
-    Exit,
     /// Run a program.
     RunProgram {
         /// The program to run.
         program: Box<dyn Program>,
     },
+
+    /// Make the bell sound.
+    Bell,
+
+    /// Exit Insh.
+    Exit,
 }


### PR DESCRIPTION
Add the making of the bell sound (via the ASCII bell 0x7).

For now, we only make the bell sound when an invalid command is entered, not one a valid idempotent one is entered. For example if in the browser, and the last entry is selected and `j` is entered, then no bell sound is made.

The bell sound can be turned off via the configuration setting `general.bell`.