### PR TITLE
Wrap vim's stdout to strip some ANSI escape codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
+ "nom",
  "regex",
  "serde",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,8 @@ lazy_static = "1.4.0"
 log = { version = "0.4.17", optional = true }
 flexi_logger = { version = "0.23.3", optional = true }
 
+# Used to create a parser for text with ANSI escape codes.
+nom = "7.1.1"
+
 [dev-dependencies]
 test-case = "2.0.0"

--- a/src/ansi_escaped_text.rs
+++ b/src/ansi_escaped_text.rs
@@ -1,0 +1,83 @@
+/*!
+A parser for text with ANSI escape codes.
+*/
+use nom::branch::alt;
+use nom::bytes::streaming::{tag, take};
+use nom::combinator::value;
+use nom::IResult as ParseResult;
+
+use nom::combinator::map;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ANSIEscapedText {
+    ANSIEscapeCode(ANSIEscapeCode),
+    Character(u8),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ANSIEscapeCode {
+    EnableAlternativeScreen,
+    DisableAlternativeScreen,
+}
+
+pub fn parser(input: &[u8]) -> ParseResult<&[u8], ANSIEscapedText> {
+    alt((
+        map(ansi_escape_code, |ansi_escape_code: ANSIEscapeCode| {
+            ANSIEscapedText::ANSIEscapeCode(ansi_escape_code)
+        }),
+        map(take(1usize), |bytes: &[u8]| {
+            ANSIEscapedText::Character(bytes[0])
+        }),
+    ))(input)
+}
+
+fn ansi_escape_code(input: &[u8]) -> ParseResult<&[u8], ANSIEscapeCode> {
+    let (input, _) = control_sequence_introducer(input)?;
+
+    // TODO: Eventually use `alt` to parse other escape codes too.
+    alternative_screen(input)
+}
+
+fn alternative_screen(input: &[u8]) -> ParseResult<&[u8], ANSIEscapeCode> {
+    let (input, _) = tag(&[0x3F, 0x31, 0x30, 0x34, 0x39])(input)?; // ? 1049
+
+    alt((
+        value(ANSIEscapeCode::EnableAlternativeScreen, tag(&[0x68])), // h
+        value(ANSIEscapeCode::DisableAlternativeScreen, tag(&[0x6C])), // l
+    ))(input)
+}
+
+fn control_sequence_introducer(input: &[u8]) -> ParseResult<&[u8], &[u8]> {
+    tag(&[0x1B, 0x5B])(input) // `<Esc> [`
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use test_case::test_case;
+
+    #[test_case(&[0x61], Ok((&[], ANSIEscapedText::Character(0x61))); "the single letter a")]
+    #[test_case(&[0x1B, 0x5B, 0x3F, 0x31, 0x30, 0x34, 0x39, 0x68], Ok((&[], ANSIEscapedText::ANSIEscapeCode(ANSIEscapeCode::EnableAlternativeScreen))); "enable alternative screen")]
+    #[test_case(&[0x1B, 0x5B, 0x3F, 0x31, 0x30, 0x34, 0x39, 0x6C], Ok((&[], ANSIEscapedText::ANSIEscapeCode(ANSIEscapeCode::DisableAlternativeScreen))); "disable alternative screen")]
+    fn test_ansi_escaped_text(input: &[u8], expected: ParseResult<&[u8], ANSIEscapedText>) {
+        let result = parser(input);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test_case(&[0x1B, 0x5B, 0x3F, 0x31, 0x30, 0x34, 0x39, 0x68], Ok((&[], ANSIEscapeCode::EnableAlternativeScreen)); "enable alternative screen")]
+    #[test_case(&[0x1B, 0x5B, 0x3F, 0x31, 0x30, 0x34, 0x39, 0x6C], Ok((&[], ANSIEscapeCode::DisableAlternativeScreen)); "disable alternative screen")]
+    fn test_ansi_escape_code(input: &[u8], expected: ParseResult<&[u8], ANSIEscapeCode>) {
+        let result = ansi_escape_code(input);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test_case(&[0x1B, 0x5B], Ok((&[], &[0x1B, 0x5B])); "the control sequence introducer")]
+    fn test_control_sequence_introducer(input: &[u8], expected: ParseResult<&[u8], &[u8]>) {
+        let result = control_sequence_introducer(input);
+
+        assert_eq!(result, expected);
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,7 +6,6 @@ use crate::system_effect::SystemEffect;
 
 use std::io::{self, Stdout, Write};
 use std::panic;
-use std::process::{Child, Command};
 
 use crossterm::cursor::{Hide as HideCursor, MoveTo as MoveCursorTo, Show as ShowCursor};
 use crossterm::event::{read, Event as CrosstermEvent};
@@ -47,6 +46,8 @@ impl App {
                         self.make_bell_sound();
                     }
                     SystemEffect::Exit => {
+                        #[cfg(feature = "logging")]
+                        log::info!("Exiting.");
                         self.teardown();
                         return;
                     }
@@ -71,6 +72,8 @@ impl App {
                     self.make_bell_sound();
                 }
                 Some(SystemEffect::Exit) => {
+                    #[cfg(feature = "logging")]
+                    log::info!("Exiting.");
                     break;
                 }
                 None => {}
@@ -98,10 +101,7 @@ impl App {
             self.update_terminal();
         }
 
-        let mut command: Command = (*program).run();
-        let mut child: Child = command.spawn().unwrap();
-
-        let _ = child.wait();
+        (*program).run();
 
         let cleanup: ProgramCleanup = program.cleanup();
         if cleanup.hide_cursor {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 #[macro_use]
 extern crate lazy_static;
 
+mod ansi_escaped_text;
 mod app;
 mod args;
 mod ascii;

--- a/src/program.rs
+++ b/src/program.rs
@@ -2,8 +2,6 @@
 This module contains the [`Program`] trait which is used to represent programs that can be run.
 */
 
-use std::process::Command;
-
 /**
 A program that can be run and is allowed to take over rendering of the terminal.
 */
@@ -18,8 +16,8 @@ pub trait Program {
         ProgramCleanup::default()
     }
 
-    /// Return a [`Command`] to run the program.
-    fn run(&self) -> Command;
+    /// Run the program.
+    fn run(&self);
 }
 
 /**

--- a/src/programs/bash.rs
+++ b/src/programs/bash.rs
@@ -3,7 +3,7 @@ Contains the [`Program`] [`Bash`].
 */
 use crate::program::{Program, ProgramCleanup, ProgramSetup};
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 
 /// A Bash program.
 pub struct Bash {
@@ -35,12 +35,14 @@ impl Program for Bash {
         }
     }
 
-    fn run(&self) -> Command {
+    fn run(&self) {
         let mut command = Command::new("bash");
         command
             .current_dir(self.directory.clone())
             .stdin(Stdio::inherit())
             .stdout(Stdio::inherit());
-        command
+
+        let mut child: Child = command.spawn().unwrap();
+        let _ = child.wait();
     }
 }

--- a/src/programs/vim.rs
+++ b/src/programs/vim.rs
@@ -2,10 +2,14 @@
 Contains the [`Program`] [`Vim`].
 */
 
+use crate::ansi_escaped_text::{self, ANSIEscapeCode, ANSIEscapedText};
 use crate::program::{Program, ProgramCleanup};
-use std::process::{Command, Stdio};
 
+use std::io::{self, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdout, Command, Stdio};
+
+use nom::{Err as ParseError, IResult as ParseResult};
 
 /// The `vim` program.
 pub struct Vim {
@@ -28,8 +32,20 @@ impl Program for Vim {
         }
     }
 
-    fn run(&self) -> Command {
+    /// Run the vim program.
+    ///
+    /// One important thing this does is strip the ANSI escape codes for enabling and disabling the
+    /// the alternative screen from the output of vim. This is accomplished by parsing the output
+    /// using `nom`. While `nom` allows for "streaming" it does not actually save the partial state
+    /// which means we are re-parsing a lot. The `combine` crate does supposedly allow for saving
+    /// the partial state which means each byte is only passed to the parser once, but I was unable
+    /// to get code using it to compile. I made an GitHub issue to try to get some help but have
+    /// yet to hear back (https://github.com/Marwes/combine/issues/354).
+    fn run(&self) {
         let mut command = Command::new("vim");
+
+        // Tell vim that it's output is not a terminal so that it doesn't output a warning message.
+        command.arg("--not-a-term");
 
         if let Some(path) = self.args.path() {
             command.arg(path.clone());
@@ -46,9 +62,82 @@ impl Program for Vim {
             }
         }
 
-        command.stdin(Stdio::inherit()).stdout(Stdio::inherit());
+        command.stdin(Stdio::inherit()).stdout(Stdio::piped());
 
-        command
+        #[cfg(feature = "logging")]
+        log::debug!("Starting vim...");
+        let mut child: Child = command.spawn().unwrap();
+        #[cfg(feature = "logging")]
+        log::debug!("Started vim.");
+
+        let command_stdout: ChildStdout = child.stdout.take().unwrap();
+        let mut reader: BufReader<ChildStdout> = BufReader::new(command_stdout);
+
+        // This buffer is used to read one byte at a time from the stdout.
+        let mut read_buffer: [u8; 1] = [0; 1];
+
+        // This buffer is used to pass bytes to the parser.
+        let mut buffer: Vec<u8> = vec![];
+
+        let mut stdout = io::stdout().lock();
+        let mut should_read: bool = true;
+        loop {
+            if should_read {
+                let length: usize = reader.read(&mut read_buffer).unwrap();
+                if length == 0 {
+                    break;
+                }
+                buffer.extend_from_slice(&read_buffer);
+            }
+
+            let buffer_clone = buffer.clone();
+            let parse_result: ParseResult<&[u8], ANSIEscapedText> =
+                ansi_escaped_text::parser(&buffer_clone);
+            match parse_result {
+                Err(ParseError::Incomplete(_needed)) => {}
+                #[cfg(feature = "logging")]
+                Err(error) => {
+                    #[cfg(feature = "logging")]
+                    log::error!("Error while parsing stdout of vim: {}", error)
+                }
+                #[cfg(not(feature = "logging"))]
+                Err(_) => {}
+                Ok((remaining, ansi_escaped_text)) => {
+                    match ansi_escaped_text {
+                        ANSIEscapedText::ANSIEscapeCode(ansi_escape_code) => match ansi_escape_code
+                        {
+                            ANSIEscapeCode::EnableAlternativeScreen => {
+                                #[cfg(feature = "logging")]
+                                log::debug!("Stripping enable alternative screen ANSI escape code from vim's output.");
+                            }
+                            ANSIEscapeCode::DisableAlternativeScreen => {
+                                #[cfg(feature = "logging")]
+                                log::debug!("Stripping disable alternative screen ANSI escape code from vim's output.");
+                            }
+                        },
+                        ANSIEscapedText::Character(character) => {
+                            stdout.write_all(&[character]).unwrap();
+                            // TODO: Can we figure out a way to not flush after every character but
+                            // only flush when vim does? Maybe based on the output?
+                            stdout.flush().unwrap();
+                        }
+                    };
+
+                    buffer.clear();
+                    if !remaining.is_empty() {
+                        should_read = false;
+                        buffer.extend_from_slice(remaining);
+                    } else {
+                        should_read = true;
+                    }
+                }
+            }
+        }
+
+        let _ = child.wait();
+
+        #[cfg(feature = "logging")]
+        log::debug!("Finished running vim.");
     }
 }
 


### PR DESCRIPTION
Wrap vim's stdout, parse it using `nom` and strip the ANSI escape codes to disable and enable the alternative screen since we are already using the alternative screen. The disable alternative screen was causing text to be leftover on the screen when Insh exited.