### PR TITLE
Fix handling of rapid input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.4.5
+- Fix handling of rapid input (for example pasting or keys that send ANSI escape codes).
+
 # 0.4.4
 - Add creating a directory with `C` from the file browser.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "insh"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "bincode",
  "clap",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "inshd"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "bincode",
  "clap",

--- a/insh/Cargo.toml
+++ b/insh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insh"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 
 [[bin]]

--- a/inshd/Cargo.toml
+++ b/inshd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inshd"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 description = "A daemon for insh."
 


### PR DESCRIPTION
Fix handling of rapid input. For example pressing an arrow key (which sends more than one byte) or pasting.

It turns out that poll seems to only do edge detection. So for example if there become 3 bytes to read, poll will trigger. But then if you only read 1 byte, poll will not trigger if called again.